### PR TITLE
Added special cases for psd processing when working with spritesheets.

### DIFF
--- a/SpriteBuilder/ccBuilder/CCBPublisher.m
+++ b/SpriteBuilder/ccBuilder/CCBPublisher.m
@@ -241,10 +241,10 @@
     }
     
     // Fetch new name
-    NSString* dstPathProposal = [[FCFormatConverter defaultConverter] proposedNameForConvertedImageAtPath:dstPath format:format dither:dither compress:compress];
+    NSString* dstPathProposal = [[FCFormatConverter defaultConverter] proposedNameForConvertedImageAtPath:dstPath format:format compress:compress isSpriteSheet:isSpriteSheet];
     
     // Add renaming rule
-    NSString* relPathRenamed = [[FCFormatConverter defaultConverter] proposedNameForConvertedImageAtPath:relPath format:format dither:dither compress:compress];
+    NSString* relPathRenamed = [[FCFormatConverter defaultConverter] proposedNameForConvertedImageAtPath:relPath format:format compress:compress isSpriteSheet:isSpriteSheet];
     [self addRenamingRuleFrom:relPath to:relPathRenamed];
     
     // Copy and convert the image
@@ -267,7 +267,7 @@
         [fm copyItemAtPath:srcPath toPath:dstPath error:NULL];
         
         // Convert it
-        NSString* dstPathConverted = [[FCFormatConverter defaultConverter] convertImageAtPath:dstPath format:format dither:dither compress:compress];
+        NSString* dstPathConverted = [[FCFormatConverter defaultConverter] convertImageAtPath:dstPath format:format dither:dither compress:compress isSpriteSheet:isSpriteSheet];
         
         // Update modification date
         [CCBFileUtil setModificationDate:srcDate forFile:dstPathConverted];
@@ -291,7 +291,7 @@
         [[ResourceManager sharedManager] createCachedImageFromAuto:srcAutoPath saveAs:dstPath forResolution:resolution];
         
         // Convert it
-        NSString* dstPathConverted = [[FCFormatConverter defaultConverter] convertImageAtPath:dstPath format:format dither:dither compress:compress];
+        NSString* dstPathConverted = [[FCFormatConverter defaultConverter] convertImageAtPath:dstPath format:format dither:dither compress:compress isSpriteSheet:isSpriteSheet];
         
         // Update modification date
         [CCBFileUtil setModificationDate:srcDate forFile:dstPathConverted];

--- a/SpriteBuilder/libs/FCFormatConverter/FCFormatConverter.h
+++ b/SpriteBuilder/libs/FCFormatConverter/FCFormatConverter.h
@@ -32,8 +32,8 @@ enum {
 
 + (FCFormatConverter*) defaultConverter;
 
-- (NSString*) proposedNameForConvertedImageAtPath:(NSString*)srcPath format:(int)format dither:(BOOL)dither compress:(BOOL)compress;
-- (NSString*) convertImageAtPath:(NSString*)srcPath format:(int)format dither:(BOOL)dither compress:(BOOL)compress;
+- (NSString*) proposedNameForConvertedImageAtPath:(NSString*)srcPath format:(int)format compress:(BOOL)compress isSpriteSheet:(BOOL)isSpriteSheet;
+- (NSString*) convertImageAtPath:(NSString*)srcPath format:(int)format dither:(BOOL)dither compress:(BOOL)compress isSpriteSheet:(BOOL)isSpriteSheet;
 
 - (NSString*) proposedNameForConvertedSoundAtPath:(NSString*)srcPath format:(int)format quality:(int)quality;
 - (NSString*) convertSoundAtPath:(NSString*)srcPath format:(int)format quality:(int)quality;

--- a/SpriteBuilder/libs/FCFormatConverter/FCFormatConverter.m
+++ b/SpriteBuilder/libs/FCFormatConverter/FCFormatConverter.m
@@ -25,6 +25,7 @@ static FCFormatConverter* gDefaultConverter = NULL;
 {
     if ( isSpriteSheet )
 		{
+		    // The name of a sprite in a spritesheet never changes.
 		    return [[srcPath copy] autorelease];
 		}
     if (format == kFCImageFormatPNG ||

--- a/SpriteBuilder/libs/FCFormatConverter/FCFormatConverter.m
+++ b/SpriteBuilder/libs/FCFormatConverter/FCFormatConverter.m
@@ -21,8 +21,12 @@ static FCFormatConverter* gDefaultConverter = NULL;
     return gDefaultConverter;
 }
 
-- (NSString*) proposedNameForConvertedImageAtPath:(NSString*)srcPath format:(int)format dither:(BOOL)dither compress:(BOOL)compress
+- (NSString*) proposedNameForConvertedImageAtPath:(NSString*)srcPath format:(int)format compress:(BOOL)compress isSpriteSheet:(BOOL)isSpriteSheet
 {
+    if ( isSpriteSheet )
+		{
+		    return [[srcPath copy] autorelease];
+		}
     if (format == kFCImageFormatPNG ||
         format == kFCImageFormatPNG_8BIT)
     {
@@ -49,13 +53,14 @@ static FCFormatConverter* gDefaultConverter = NULL;
     return NULL;
 }
 
-- (NSString*) convertImageAtPath:(NSString*)srcPath format:(int)format dither:(BOOL)dither compress:(BOOL)compress
+- (NSString*) convertImageAtPath:(NSString*)srcPath format:(int)format dither:(BOOL)dither compress:(BOOL)compress isSpriteSheet:(BOOL)isSpriteSheet
 {
     NSFileManager* fm = [NSFileManager defaultManager];
     NSString* dstDir = [srcPath stringByDeletingLastPathComponent];
     
 		// Convert PSD to PNG as a pre-step.
-		if ( [[srcPath pathExtension] isEqualToString:@"psd"] )
+		// Unless the .psd is part of a spritesheet, then the original name has to be preserved.
+		if ( [[srcPath pathExtension] isEqualToString:@"psd"] && !isSpriteSheet)
 		{
 				CGImageSourceRef image_source = CGImageSourceCreateWithURL((CFURLRef)[NSURL fileURLWithPath:srcPath], NULL);
 				CGImageRef image = CGImageSourceCreateImageAtIndex(image_source, 0, NULL);

--- a/SpriteBuilder/libs/Tupac/Tupac.mm
+++ b/SpriteBuilder/libs/Tupac/Tupac.mm
@@ -216,7 +216,6 @@ typedef struct _PVRTexHeader
     for (NSString *filename in self.filenames)
     {
         // Load CGImage
-//				#error HERE!
 				CGImageSourceRef image_source = CGImageSourceCreateWithURL((CFURLRef)[NSURL fileURLWithPath:filename], NULL);
 				CGImageRef srcImage = CGImageSourceCreateImageAtIndex(image_source, 0, NULL);
         
@@ -247,7 +246,7 @@ typedef struct _PVRTexHeader
         [images addObject:[NSValue valueWithPointer:srcImage]];
         
         // Relase objects (images released later)
-        //CGDataProviderRelease(dataProvider);
+        CFRelease(image_source);
     }
     
     // Check that the output format is valid

--- a/SpriteBuilder/libs/Tupac/Tupac.mm
+++ b/SpriteBuilder/libs/Tupac/Tupac.mm
@@ -216,8 +216,9 @@ typedef struct _PVRTexHeader
     for (NSString *filename in self.filenames)
     {
         // Load CGImage
-        CGDataProviderRef dataProvider = CGDataProviderCreateWithFilename([filename cStringUsingEncoding:NSUTF8StringEncoding]);
-        CGImageRef srcImage = CGImageCreateWithPNGDataProvider(dataProvider, NULL, NO, kCGRenderingIntentDefault);
+//				#error HERE!
+				CGImageSourceRef image_source = CGImageSourceCreateWithURL((CFURLRef)[NSURL fileURLWithPath:filename], NULL);
+				CGImageRef srcImage = CGImageSourceCreateImageAtIndex(image_source, 0, NULL);
         
         // Get info
         int w = (int)CGImageGetWidth(srcImage);
@@ -246,7 +247,7 @@ typedef struct _PVRTexHeader
         [images addObject:[NSValue valueWithPointer:srcImage]];
         
         // Relase objects (images released later)
-        CGDataProviderRelease(dataProvider);
+        //CGDataProviderRelease(dataProvider);
     }
     
     // Check that the output format is valid
@@ -425,7 +426,7 @@ typedef struct _PVRTexHeader
         [[NSFileManager defaultManager] copyItemAtPath:pngFilename toPath:self.previewFile error:NULL];
     }
     
-    textureFileName = [[FCFormatConverter defaultConverter] convertImageAtPath:pngFilename format:imageFormat_ dither:dither_ compress:compress_];
+    textureFileName = [[FCFormatConverter defaultConverter] convertImageAtPath:pngFilename format:imageFormat_ dither:dither_ compress:compress_ isSpriteSheet:YES];
     
     // Metadata File Export
     textureFileName = [textureFileName lastPathComponent];
@@ -510,7 +511,8 @@ typedef struct _PVRTexHeader
         
         for (NSString* file in files)
         {
-            if ([[[file pathExtension] lowercaseString] isEqualToString:@"png"])
+				    NSString *lower = [[file pathExtension] lowercaseString];
+            if ([lower isEqualToString:@"png"] || [lower isEqualToString:@"psd"])
             {
                 [allFiles addObject:[file lastPathComponent]];
             }


### PR DESCRIPTION
The solution is a little goofy. It adds more special logic when processing a psd file for a spritesheet, but it works correctly.

The original .psd names end up in the sprite sheet .plist instead of the fileLookup.plist.
