### PR TITLE
Fix SpriteBuilder colors to work with the float CCColor changes.

### DIFF
--- a/SpriteBuilder/ccBuilder/CCBWriterInternal.m
+++ b/SpriteBuilder/ccBuilder/CCBWriterInternal.m
@@ -141,7 +141,7 @@
 
 + (id) serializeColor4:(CCColor*)c
 {
-    CGFloat r,g,b,a;
+    float r,g,b,a;
     [c getRed:&r green:&g blue:&b alpha:&a];
     
     return [NSArray arrayWithObjects:

--- a/SpriteBuilder/ccBuilder/InspectorColor3.m
+++ b/SpriteBuilder/ccBuilder/InspectorColor3.m
@@ -34,8 +34,8 @@
     color = [color colorUsingColorSpace:[NSColorSpace deviceRGBColorSpace]];
     
     [color getRed:&r green:&g blue:&b alpha:&a];
-    
-    CCColor* colorValue = [CCColor colorWithRed:r green:g blue:b alpha:1];
+
+		CCColor* colorValue = [CCColor colorWithRed:r green:g blue:b alpha:1];
     [self setPropertyForSelection:colorValue];
     
     [self updateAnimateablePropertyValue: [CCBWriterInternal serializeColor4:colorValue]];
@@ -44,12 +44,8 @@
 
 - (NSColor*) color
 {
-    CCColor* colorValue = [self propertyForSelection];
-    
-    CGFloat r, g, b, a;
-    [colorValue getRed:&r green:&g blue:&b alpha:&a];
-    
-    return [NSColor colorWithCalibratedRed:r green:g blue:b alpha:1];
+	CCColor* colorValue = [self propertyForSelection];
+	return colorValue.NSColor;
 }
 
 @end

--- a/SpriteBuilder/ccBuilder/InspectorColor4.m
+++ b/SpriteBuilder/ccBuilder/InspectorColor4.m
@@ -45,12 +45,8 @@
 
 - (NSColor*) color
 {
-    CCColor* colorValue = [self propertyForSelection];
-    
-    CGFloat r, g, b, a;
-    [colorValue getRed:&r green:&g blue:&b alpha:&a];
-    
-    return [NSColor colorWithCalibratedRed:r green:g blue:b alpha:a];
+		CCColor* colorValue = [self propertyForSelection];
+		return colorValue.NSColor;
 }
 
 @end

--- a/SpriteBuilder/ccBuilder/InspectorColor4FVar.m
+++ b/SpriteBuilder/ccBuilder/InspectorColor4FVar.m
@@ -41,33 +41,27 @@
 
 - (NSColor*) color
 {
-    CCColor* colorValue = [self propertyForSelection];
-    CGFloat r, g, b, a;
-    [colorValue getRed:&r green:&g blue:&b alpha:&a];
-    
-    return [NSColor colorWithCalibratedRed:r green:g blue:b alpha:a];
+	CCColor* colorValue = [self propertyForSelection];
+	return colorValue.NSColor;
 }
 
 - (void) setColorVar:(NSColor *)color
 {
     color = [color colorUsingColorSpace:[NSColorSpace deviceRGBColorSpace]];
-    
+  
     CGFloat r, g, b, a;
     [color getRed:&r green:&g blue:&b alpha:&a];
     
     CCColor* colorValue = [CCColor colorWithRed:r green:g blue:b alpha:a];
-    
+  
     [self setPropertyForSelectionVar:colorValue];
     
 }
 
 - (NSColor*) colorVar
 {
-    CCColor* colorValue = [self propertyForSelectionVar];
-    CGFloat r,g,b,a;
-    [colorValue getRed:&r green:&g blue:&b alpha:&a];
-    
-    return [NSColor colorWithCalibratedRed:r green:g blue:b alpha:a];
+	CCColor* colorValue = [self propertyForSelectionVar];
+	return colorValue.NSColor;
 }
 
 @end


### PR DESCRIPTION
Requires my cocos2d pull request, this commit:
https://github.com/andykorth/cocos2d-iphone/commit/59ee7c090e433cabee1312b1128e8188f04d19b6

Added some convenience methods to create NSColors from CCColors. 

The random colors in SpriteBuilder were because it was dumping CGFloats (doubles on Mac) into floats. (Which was a change on the CCColor side of things. 
