### PR TITLE
Updated description on Color Node

### DIFF
--- a/SpriteBuilder/CCLayerColor/CCBPProperties.plist
+++ b/SpriteBuilder/CCLayerColor/CCBPProperties.plist
@@ -7,7 +7,7 @@
 	<key>ordering</key>
 	<integer>4000</integer>
 	<key>description</key>
-	<string>Draws a square area filled with a gradient.</string>
+	<string>Draws a square area filled with a color.</string>
 	<key>inheritsFrom</key>
 	<string>CCNode</string>
 	<key>canHaveChildren</key>


### PR DESCRIPTION
Fixes this text:

![image](https://f.cloud.github.com/assets/1760802/2059386/70514688-8ba9-11e3-914c-7a543f9fc165.png)
