### PR TITLE
Fixed (or suppressed) all compiler warnings

### DIFF
--- a/SpriteBuilder/SpriteBuilder.xcodeproj/project.pbxproj
+++ b/SpriteBuilder/SpriteBuilder.xcodeproj/project.pbxproj
@@ -5523,13 +5523,6 @@
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COPY_PHASE_STRIP = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)",
-					"\\\"$(SRCROOT)/libs\\\"",
-					SpriteBuilder,
-					SpriteBuilder/libs,
-				);
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -5570,13 +5563,6 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)",
-					"\\\"$(SRCROOT)/libs\\\"",
-					SpriteBuilder,
-					SpriteBuilder/libs,
-				);
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "ccBuilder/SpriteBuilder-Prefix.pch";

--- a/SpriteBuilder/ccBuilder/AppDelegate.h
+++ b/SpriteBuilder/ccBuilder/AppDelegate.h
@@ -116,6 +116,12 @@ enum {
 @class PhysicsHandler;
 @class WarningTableViewHandler;
 
+@protocol AppDelegate_UndeclaredSelectors <NSObject>
+@optional
+- (void) customVisit;
+- (void) oldVisit;
+@end
+
 @interface AppDelegate : NSObject <NSApplicationDelegate, NSWindowDelegate, SMTabBarDelegate, BITCrashReportManagerDelegate>
 {
     
@@ -388,6 +394,14 @@ enum {
 - (IBAction) menuCleanCacheDirectories:(id)sender;
 - (IBAction)menuAbout:(id)sender;
 - (IBAction)menuResetSpriteBuilder:(id)sender;
+
+// selectors exposed to suppress 'undeclared selector' warnings
+- (IBAction)menuPasteKeyframes:(id)sender;
+- (IBAction)menuEditSmartSpriteSheet:(id)sender;
+- (IBAction)menuActionDelete:(id)sender;
+- (IBAction)menuActionInterfaceFile:(NSMenuItem*)sender;
+- (IBAction)menuActionNewFolder:(NSMenuItem*)sender;
+- (IBAction)menuOpenExternal:(id)sender;
 
 // Undo / Redo
 - (void) updateDirtyMark;

--- a/SpriteBuilder/ccBuilder/AppDelegate.m
+++ b/SpriteBuilder/ccBuilder/AppDelegate.m
@@ -414,8 +414,6 @@ void ApplyCustomNodeVisitSwizzle()
     CGFloat r, g, b, a;
     [color getRed:&r green:&g blue:&b alpha:&a];
     
-    CCColor* colorValue = [CCColor colorWithRed:r green:g blue:b alpha:1];
-    
     NSColor * color2 = [NSColor colorWithDeviceRed:r green:g blue:b alpha:a];
     NSColor * calibratedColor = [color2 colorUsingColorSpaceName:NSCalibratedRGBColorSpace];
 
@@ -1090,13 +1088,13 @@ static BOOL hideAllToNextSeparator;
     //Undocumented function that resets the KeyViewLoop.
     if([inspectorDocumentView respondsToSelector:privateSelector])
     {
-        [inspectorDocumentView performSelector:privateSelector withObject:nil];
+		SUPPRESS_LEAK_WARNING([inspectorDocumentView performSelector:privateSelector withObject:nil]);
     }
     
     //Undocumented function that resets the KeyViewLoop.
     if([inspectorCodeDocumentView respondsToSelector:privateSelector])
     {
-        [inspectorCodeDocumentView performSelector:privateSelector withObject:nil];
+        SUPPRESS_LEAK_WARNING([inspectorCodeDocumentView performSelector:privateSelector withObject:nil]);
     }
     
 
@@ -2874,7 +2872,7 @@ static BOOL hideAllToNextSeparator;
                 
                 // Set icon of created directory
                 NSImage* folderIcon = [NSImage imageNamed:@"Folder.icns"];
-                [[NSWorkspace sharedWorkspace] setIcon:folderIcon forFile:fileName options:NULL];
+                [[NSWorkspace sharedWorkspace] setIcon:folderIcon forFile:fileName options:0];
                 
                 // Create project file
                 NSString* projectName = [fileNameRaw lastPathComponent];

--- a/SpriteBuilder/ccBuilder/AppDelegate.m
+++ b/SpriteBuilder/ccBuilder/AppDelegate.m
@@ -876,7 +876,8 @@ static BOOL hideAllToNextSeparator;
     }
     
     // Load it's associated view
-    [NSBundle loadNibNamed:inspectorNibName owner:inspectorValue];
+	// FIXME: fix deprecation warning
+    SUPPRESS_DEPRECATED([NSBundle loadNibNamed:inspectorNibName owner:inspectorValue]);
     NSView* view = inspectorValue.view;
     
     [inspectorValue willBeAdded];

--- a/SpriteBuilder/ccBuilder/AppDelegate.m
+++ b/SpriteBuilder/ccBuilder/AppDelegate.m
@@ -4078,9 +4078,9 @@ static BOOL hideAllToNextSeparator;
 
 
 
-/*
 - (IBAction)menuEditSmartSpriteSheet:(id)sender
 {
+	/*
     int selectedRow = [sender tag];
     
     if (selectedRow >= 0 && projectSettings)
@@ -4127,7 +4127,8 @@ static BOOL hideAllToNextSeparator;
             }
         }
     }
-}*/
+	 */
+}
 
 - (IBAction)menuAlignKeyframeToMarker:(id)sender
 {

--- a/SpriteBuilder/ccBuilder/CCBOutlineView.m
+++ b/SpriteBuilder/ccBuilder/CCBOutlineView.m
@@ -47,7 +47,7 @@
 
 - (void)highlightSelectionInClipRect:(NSRect)clipRect
 {
-#warning The clipping rect is a problem since the gradient spans more than one row, the hackish solution is to call setNeedsDisplay after selection has changed
+	// FIXME: The clipping rect is a problem since the gradient spans more than one row, the hackish solution is to call setNeedsDisplay after selection has changed
     NSIndexSet *selectedRowIndexes = [self selectedRowIndexes];
     
     NSRect currentRect = NSZeroRect;

--- a/SpriteBuilder/ccBuilder/CCBTextFieldCell.m
+++ b/SpriteBuilder/ccBuilder/CCBTextFieldCell.m
@@ -50,7 +50,7 @@
     }
 }
 
-#warning Doesn't work :/ Edit area is too big
+// FIXME: Doesn't work :/ Edit area is too big
 - (NSText*) setUpFieldEditorAttributes:(NSText *)textObj
 {
     textObj.maxSize = NSMakeSize(40000, 16);

--- a/SpriteBuilder/ccBuilder/CCBWriterInternal.m
+++ b/SpriteBuilder/ccBuilder/CCBWriterInternal.m
@@ -33,6 +33,10 @@
 #import "AppDelegate.h"
 #import "NodePhysicsBody.h"
 
+@protocol CCBWriterInternal_UndeclaredSelectors <NSObject>
+- (NSArray*) ccbExcludePropertiesForSave;
+@end
+
 @implementation CCBWriterInternal
 
 

--- a/SpriteBuilder/ccBuilder/HelpWindow.m
+++ b/SpriteBuilder/ccBuilder/HelpWindow.m
@@ -45,7 +45,7 @@
     mdFiles = [[NSMutableArray alloc] init];
     for (NSString* file in files)
     {
-#warning This part of documentation should be updated too
+		// TODO: This part of documentation should be updated too
         if ([file characterAtIndex:0] == 'X') continue;
         
         if ([file hasSuffix:@".md"])

--- a/SpriteBuilder/ccBuilder/InspectorStartStop.m
+++ b/SpriteBuilder/ccBuilder/InspectorStartStop.m
@@ -45,13 +45,13 @@
 - (IBAction)pressedStart:(id)sender
 {
     SEL selector = NSSelectorFromString(startMethod);
-    [selection performSelector:selector];
+    SUPPRESS_LEAK_WARNING([selection performSelector:selector]);
 }
 
 - (IBAction)pressedStop:(id)sender
 {
     SEL selector = NSSelectorFromString(stopMethod);
-    [selection performSelector:selector];
+    SUPPRESS_LEAK_WARNING([selection performSelector:selector]);
 }
 
 @end

--- a/SpriteBuilder/ccBuilder/LocalizationEditorWindow.m
+++ b/SpriteBuilder/ccBuilder/LocalizationEditorWindow.m
@@ -191,7 +191,7 @@
     NSInteger newRow = handler.translations.count -1;
     
     [tableTranslations selectRowIndexes:[NSIndexSet indexSetWithIndex:newRow] byExtendingSelection:NO];
-    [tableTranslations editColumn:1 row:newRow withEvent:NULL select:sender];
+    [tableTranslations editColumn:1 row:newRow withEvent:NULL select:YES];
 }
 
 - (IBAction)pressedAddGroup:(id)sender

--- a/SpriteBuilder/ccBuilder/NewDocWindowController.m
+++ b/SpriteBuilder/ccBuilder/NewDocWindowController.m
@@ -159,7 +159,7 @@
 - (void) dealloc
 {
 	SBLogSelf();
-    self.rootObjectType = NULL;
+    self.rootObjectType = 0;
 }
 
 @end

--- a/SpriteBuilder/ccBuilder/NotesLayer.m
+++ b/SpriteBuilder/ccBuilder/NotesLayer.m
@@ -59,7 +59,8 @@
     CGSize size = note.contentSize;
     CGPoint pos = ccp(note.position.x * [CCDirector sharedDirector].contentScaleFactor, note.position.y * [CCDirector sharedDirector].contentScaleFactor - note.contentSize.height);
     
-    [NSBundle loadNibNamed:@"StickyNoteEditView" owner:self];
+	// FIXME: fix deprecation warning
+    SUPPRESS_DEPRECATED([NSBundle loadNibNamed:@"StickyNoteEditView" owner:self]);
     [editView setFrameOrigin:NSPointFromCGPoint(pos)];
     [editView setFrameSize:NSSizeFromCGSize(size)];
     [ad.guiView addSubview:editView];

--- a/SpriteBuilder/ccBuilder/ResourceManager.m
+++ b/SpriteBuilder/ccBuilder/ResourceManager.m
@@ -383,6 +383,11 @@
 
 #pragma mark ResourceManager
 
+@protocol ResourceManager_UndeclaredSelectors <NSObject>
+@optional
+- (void) resourceListUpdated;
+@end
+
 @implementation ResourceManager
 
 @synthesize directories;

--- a/SpriteBuilder/ccBuilder/ResourceManager.m
+++ b/SpriteBuilder/ccBuilder/ResourceManager.m
@@ -1004,7 +1004,7 @@
     }
     
     // Create new, scaled image
-    CGContextRef newContext = CGBitmapContextCreate(NULL, wDst, hDst, 8, wDst*32, colorSpace, kCGImageAlphaPremultipliedLast);
+    CGContextRef newContext = CGBitmapContextCreate(NULL, wDst, hDst, 8, wDst*32, colorSpace, (CGBitmapInfo)kCGImageAlphaPremultipliedLast);
 	NSAssert(newContext != nil, @"CG draw context is nil");
     
     // Enable anti-aliasing

--- a/SpriteBuilder/ccBuilder/ResourceManagerOutlineHandler.m
+++ b/SpriteBuilder/ccBuilder/ResourceManagerOutlineHandler.m
@@ -280,7 +280,7 @@
     if ([item isKindOfClass:[RMResource class]])
     {
         RMResource* res = item;
-#warning Do all images by type
+		// FIXME: Do all images by type
         if (res.type == kCCBResTypeImage)
         {
             icon = [self smallIconForFileType:@"png"];

--- a/SpriteBuilder/ccBuilder/ResourceManagerPreviewView.m
+++ b/SpriteBuilder/ccBuilder/ResourceManagerPreviewView.m
@@ -349,7 +349,7 @@
     if (_previewedResource)
     {
         // Return if the value hasn't changed
-        int oldScaleFrom = [settings valueForResource:_previewedResource andKey:@"scaleFrom"];
+        int oldScaleFrom = [[settings valueForResource:_previewedResource andKey:@"scaleFrom"] intValue];
         if (oldScaleFrom == scaleFrom) return;
         
         if (scaleFrom)

--- a/SpriteBuilder/ccBuilder/ResourceManagerUtil.m
+++ b/SpriteBuilder/ccBuilder/ResourceManagerUtil.m
@@ -27,6 +27,11 @@
 #import "ResourceManagerUtil.h"
 #import "ResourceManager.h"
 
+@protocol ResourceManagerUtil_UndeclaredSelectors <NSObject>
+@optional
+- (void) selectedResource:(id)sender;
+@end
+
 @implementation ResourceManagerUtil
 
 + (void) setTitle:(NSString*)str forPopup:(NSPopUpButton*)popup forceMarker:(BOOL) forceMarker

--- a/SpriteBuilder/ccBuilder/ResourceManagerUtil.m
+++ b/SpriteBuilder/ccBuilder/ResourceManagerUtil.m
@@ -294,7 +294,7 @@
 {
     NSImage* icon = NULL;
     
-#warning Do all images by type
+	// FIXME: Do all images by type
     if (res.type == kCCBResTypeImage)
     {
         icon = [ResourceManagerUtil smallIconForFileType:@"png"];

--- a/SpriteBuilder/ccBuilder/SequencerExpandBtnCell.m
+++ b/SpriteBuilder/ccBuilder/SequencerExpandBtnCell.m
@@ -134,8 +134,6 @@
     copy->expandedImage = nil;
     copy.collapsedImage = [self.collapsedImage copyWithZone:zone];
     copy.expandedImage = [self.expandedImage copyWithZone:zone];
-    copy.collapsedImage;
-    copy.expandedImage;
     
     return copy;
 }

--- a/SpriteBuilder/ccBuilder/SequencerHandler.h
+++ b/SpriteBuilder/ccBuilder/SequencerHandler.h
@@ -101,4 +101,9 @@
 
 - (void) menuAddKeyframeNamed:(NSString*)keyframeName;
 - (BOOL) canInsertKeyframeNamed:(NSString*)prop;
+
+// selectors exposed to prevent 'undeclared selector' warning
+- (void) menuSetSequence:(id)sender;
+- (void) menuSetChainedSequence:(id)sender;
+
 @end

--- a/SpriteBuilder/ccBuilder/SequencerKeyframe.h
+++ b/SpriteBuilder/ccBuilder/SequencerKeyframe.h
@@ -83,4 +83,7 @@ NSString * kClipboardChannelKeyframes;
 - (BOOL) valueIsEqualTo:(SequencerKeyframe*)keyframe;
 - (BOOL) supportsFiniteTimeInterpolations;
 
+// selectors exposed to prevent 'undeclared selector' warning
+- (NSComparisonResult) compareTime:(id)cmp;
+
 @end

--- a/SpriteBuilder/ccBuilder/SequencerPopoverHandler.m
+++ b/SpriteBuilder/ccBuilder/SequencerPopoverHandler.m
@@ -64,7 +64,8 @@
     InspectorValue* inspectorValue = [InspectorValue inspectorOfType:type withSelection:node andPropertyName:prop andDisplayName:prop andExtra:NULL];
     inspectorValue.inPopoverWindow = YES;
     
-    [NSBundle loadNibNamed:inspectorNibName owner:inspectorValue];
+	// FIXME: fix deprecation warning
+    SUPPRESS_DEPRECATED([NSBundle loadNibNamed:inspectorNibName owner:inspectorValue]);
     NSView* view = inspectorValue.view;
     [view setBoundsOrigin:NSMakePoint(0, 0)];
     
@@ -96,7 +97,8 @@
         {
             SequencerPopoverBlock* owner = [[SequencerPopoverBlock alloc] init];
             owner.keyframe = kf;
-            [NSBundle loadNibNamed:@"SequencerPopoverBlock" owner:owner];
+			// FIXME: fix deprecation warning
+			SUPPRESS_DEPRECATED([NSBundle loadNibNamed:@"SequencerPopoverBlock" owner:owner]);
             NSView* view = owner.view;
             
             [vc.view setFrameSize:NSMakeSize(view.bounds.size.width, view.bounds.size.height*kfs.count)];
@@ -112,7 +114,8 @@
         {
             SequencerPopoverSound* owner = [[SequencerPopoverSound alloc] init];
             owner.keyframe = kf;
-            [NSBundle loadNibNamed:@"SequencerPopoverSound" owner:owner];
+			// FIXME: fix deprecation warning
+			SUPPRESS_DEPRECATED([NSBundle loadNibNamed:@"SequencerPopoverSound" owner:owner]);
             NSView* view = owner.view;
             
             [vc.view setFrameSize:NSMakeSize(view.bounds.size.width, view.bounds.size.height*kfs.count)];

--- a/SpriteBuilder/ccBuilder/SpriteBuilder-Prefix.pch
+++ b/SpriteBuilder/ccBuilder/SpriteBuilder-Prefix.pch
@@ -15,3 +15,16 @@
 #   define WARN(...)
 #	define SBLogSelf() do{} while(0)
 #endif
+
+/** Suppress a compiler warning regarding the performSelector: method. */
+#define SUPPRESS_LEAK_WARNING(code)                        \
+_Pragma("clang diagnostic push")                                        \
+_Pragma("clang diagnostic ignored \"-Warc-performSelector-leaks\"")     \
+code;                                                                   \
+_Pragma("clang diagnostic pop")                                         \
+
+#define SUPPRESS_DEPRECATED_WARNING(code) \
+_Pragma("clang diagnostic push")                                        \
+_Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")     \
+code;                                                                   \
+_Pragma("clang diagnostic pop")                                         \

--- a/SpriteBuilder/ccBuilder/SpriteBuilder-Prefix.pch
+++ b/SpriteBuilder/ccBuilder/SpriteBuilder-Prefix.pch
@@ -17,7 +17,7 @@
 #endif
 
 /** Suppress a compiler warning regarding the performSelector: method. */
-#define SUPPRESS_LEAK_WARNING(code)                        \
+#define SUPPRESS_LEAK_WARNING(code) \
 _Pragma("clang diagnostic push")                                        \
 _Pragma("clang diagnostic ignored \"-Warc-performSelector-leaks\"")     \
 code;                                                                   \
@@ -25,6 +25,12 @@ _Pragma("clang diagnostic pop")                                         \
 
 #define SUPPRESS_DEPRECATED_WARNING(code) \
 _Pragma("clang diagnostic push")                                        \
-_Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")     \
+_Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")		\
+code;                                                                   \
+_Pragma("clang diagnostic pop")                                         \
+
+#define SUPPRESS_UNDECLARED_SELECTOR(code) \
+_Pragma("clang diagnostic push")                                        \
+_Pragma("clang diagnostic ignored \"-Wundeclared-selector\"")			\
 code;                                                                   \
 _Pragma("clang diagnostic pop")                                         \

--- a/SpriteBuilder/ccBuilder/SpriteBuilder-Prefix.pch
+++ b/SpriteBuilder/ccBuilder/SpriteBuilder-Prefix.pch
@@ -34,3 +34,9 @@ _Pragma("clang diagnostic push")                                        \
 _Pragma("clang diagnostic ignored \"-Wundeclared-selector\"")			\
 code;                                                                   \
 _Pragma("clang diagnostic pop")                                         \
+
+#define SUPPRESS_DEPRECATED(code) \
+_Pragma("clang diagnostic push")                                        \
+_Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")		\
+code;                                                                   \
+_Pragma("clang diagnostic pop")                                         \

--- a/SpriteBuilder/libs/FCFormatConverter/FCFormatConverter.mm
+++ b/SpriteBuilder/libs/FCFormatConverter/FCFormatConverter.mm
@@ -246,17 +246,14 @@ static NSString * kErrorDomain = @"com.apportable.SpriteBuilder";
         return YES;
         
     }
-    else
-    {
-        // Conversion failed
-        if(error != nil)
-        {
-            *error = [NSError errorWithDomain:kErrorDomain code:EPERM userInfo:@{NSLocalizedDescriptionKey:@"Unhandled format"}];
-        }
-        
-        return NO;
-    }
     
+	// Conversion failed
+	if(error != nil)
+	{
+		*error = [NSError errorWithDomain:kErrorDomain code:EPERM userInfo:@{NSLocalizedDescriptionKey:@"Unhandled format"}];
+	}
+	
+	return NO;
 }
 
 - (NSString*) proposedNameForConvertedSoundAtPath:(NSString*)srcPath format:(int)format quality:(int)quality

--- a/SpriteBuilder/libs/HockeySDK.framework/Versions/A/Headers/BITCrashReportManagerDelegate.h
+++ b/SpriteBuilder/libs/HockeySDK.framework/Versions/A/Headers/BITCrashReportManagerDelegate.h
@@ -28,11 +28,11 @@
 @protocol BITCrashReportManagerDelegate <NSObject>
 
 @required
+@optional
 
 // Invoked once the modal sheets are gone
+// SI: seems unused, no reference to this method anywhere, made @optional
 - (void) showMainApplicationWindow;
-
-@optional
 
 // Invoked before a crash report will be sent
 // 

--- a/SpriteBuilder/libs/InspectorTabBar/SMBar.m
+++ b/SpriteBuilder/libs/InspectorTabBar/SMBar.m
@@ -113,7 +113,7 @@ static CGImageRef SMNoiseImageCreate(NSUInteger width, NSUInteger height, CGFloa
     }
     
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceGray();
-    CGContextRef bitmapContext = CGBitmapContextCreate(rgba, width, height, 8, width, colorSpace, kCGImageAlphaNone);
+    CGContextRef bitmapContext = CGBitmapContextCreate(rgba, width, height, 8, width, colorSpace, (CGBitmapInfo)kCGImageAlphaNone);
     CFRelease(colorSpace);
     free(rgba);
     

--- a/SpriteBuilder/libs/TabBar/PSMTabBarCell.m
+++ b/SpriteBuilder/libs/TabBar/PSMTabBarCell.m
@@ -324,7 +324,7 @@
 
 	// scrubtastic
 	if([_ctrlView allowsScrubbing] && ([theEvent modifierFlags] & NSAlternateKeyMask)) {
-		[_ctrlView performSelector:@selector(tabClick:) withObject:self];
+		SUPPRESS_UNDECLARED_SELECTOR([_ctrlView performSelector:@selector(tabClick:) withObject:self]);
 	}
 
 	// tell the control we only need to redraw the affected tab
@@ -469,7 +469,7 @@
 - (void)accessibilityPerformAction:(NSString *)action {
 	if([action isEqualToString:NSAccessibilityPressAction]) {
 		// this tab was selected
-		[_ctrlView performSelector:@selector(tabClick:) withObject:self];
+		SUPPRESS_UNDECLARED_SELECTOR([_ctrlView performSelector:@selector(tabClick:) withObject:self]);
 	}
 }
 

--- a/SpriteBuilder/libs/TabBar/PSMTabBarControl.m
+++ b/SpriteBuilder/libs/TabBar/PSMTabBarControl.m
@@ -576,6 +576,8 @@
 	[cell unbind:@"countColor"];
 	[cell unbind:@"isEdited"];
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
 	if([item identifier] != nil) {
 		if([[item identifier] respondsToSelector:@selector(isProcessing)]) {
 			[[item identifier] removeObserver:cell forKeyPath:@"isProcessing"];
@@ -611,6 +613,7 @@
 			[[item identifier] removeObserver:cell forKeyPath:@"isEdited"];
 		}
 	}
+#pragma clang diagnostic pop
 
 	// stop watching identifier
 	[item removeObserver:self forKeyPath:@"identifier"];
@@ -1738,6 +1741,10 @@
 - (void)_bindPropertiesForCell:(PSMTabBarCell *)cell andTabViewItem:(NSTabViewItem *)item {
 	// bind the indicator to the represented object's status (if it exists)
 	[[cell indicator] setHidden:YES];
+	
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+
 	if([item identifier] != nil) {
 		if([[[cell representedObject] identifier] respondsToSelector:@selector(isProcessing)]) {
 			NSMutableDictionary *bindingOptions = [NSMutableDictionary dictionary];
@@ -1795,6 +1802,8 @@
 			[[item identifier] addObserver:cell forKeyPath:@"isEdited" options:0 context:nil];
 		}
 	}
+
+#pragma clang diagnostic pop
 
 	// bind my string value to the label on the represented tab
 	[cell bind:@"title" toObject:item withKeyPath:@"label" options:nil];

--- a/SpriteBuilder/libs/TabBar/PSMTabBarController.m
+++ b/SpriteBuilder/libs/TabBar/PSMTabBarController.m
@@ -584,9 +584,13 @@ static NSInteger potentialMinimumForArray(NSArray *array, NSInteger minimum){
 			}
 
 			// Each item's title is limited to 60 characters. If more than 60 characters, use an ellipsis to indicate that more exists.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
 			menuItem = [_overflowMenu addItemWithTitle:[[[cell attributedStringValue] string] stringWithEllipsisByTruncatingToLength:MAX_OVERFLOW_MENUITEM_TITLE_LENGTH]
 						action:@selector(overflowMenuAction:)
 						keyEquivalent:@""];
+#pragma clang diagnostics pop
+			
 			[menuItem setTarget:_control];
 			[menuItem setRepresentedObject:[cell representedObject]];
 

--- a/SpriteBuilder/libs/ThoMoNetworking/ThoMoNetworkStub.m
+++ b/SpriteBuilder/libs/ThoMoNetworking/ThoMoNetworkStub.m
@@ -224,7 +224,7 @@ NSString *const kThoMoNetworkPrefScopeSpecifierKey				= @"kThoMoNetworkPrefScope
 		[self teardown];
 	}
 	
-	[self performSelectorOnMainThread:@selector(networkStubDidShutDownRelayMethod) withObject:nil waitUntilDone:NO];
+	SUPPRESS_UNDECLARED_SELECTOR([self performSelectorOnMainThread:@selector(networkStubDidShutDownRelayMethod) withObject:nil waitUntilDone:NO]);
 	
 	[networkThreadPool release];
 }

--- a/SpriteBuilder/libs/ThoMoNetworking/ThoMoNetworkStub.m
+++ b/SpriteBuilder/libs/ThoMoNetworking/ThoMoNetworkStub.m
@@ -150,7 +150,7 @@ NSString *const kThoMoNetworkPrefScopeSpecifierKey				= @"kThoMoNetworkPrefScope
 {
 //   NSData *sendData = [NSKeyedArchiver archivedDataWithRootObject:theData];
     NSError *error;
-    NSData *sendData = [NSPropertyListSerialization dataWithPropertyList:theData format:NSPropertyListBinaryFormat_v1_0 options:NULL error:&error];
+    NSData *sendData = [NSPropertyListSerialization dataWithPropertyList:theData format:NSPropertyListBinaryFormat_v1_0 options:0 error:&error];
     
 	[self sendByteData:sendData toConnection:theConnectionIdString];
 }
@@ -249,7 +249,7 @@ NSString *const kThoMoNetworkPrefScopeSpecifierKey				= @"kThoMoNetworkPrefScope
 	//id receivedData = [NSKeyedUnarchiver unarchiveObjectWithData:theData];
 	
     NSError *error;
-    NSDictionary *receivedData = [NSPropertyListSerialization propertyListWithData:theData options:NULL format:NULL error:&error];
+    NSDictionary *receivedData = [NSPropertyListSerialization propertyListWithData:theData options:0 format:NULL error:&error];
     
     // package the parameters into an info dict and relay them to the main thread
 	NSDictionary *infoDict = [NSDictionary dictionaryWithObjectsAndKeys:	


### PR DESCRIPTION
I got bored :)

libs: warnings merely suppressed
sb: 
- fixed warnings properly where possible
- some undeclared selectors fixed using protocol so the warning will resurface if selector in question is renamed
- suppress loadNibNamed: deprecation warnings (added a FIXME comment)
- removed framework search paths from target "SpriteBuilder" because they generated "directory not found" warnings. The SpriteBuilder build settings already had the correct framework search path set: "libs".

This can be closed:
https://github.com/apportable/SpriteBuilder/issues/90
