### PR TITLE
Fixed issue #253: Project Settings option causes the app to crash when no .ccb is opened.

### DIFF
--- a/SpriteBuilder/ccBuilder/AppDelegate.m
+++ b/SpriteBuilder/ccBuilder/AppDelegate.m
@@ -3286,7 +3286,12 @@ static BOOL hideAllToNextSeparator;
 
 - (void) updatePositionScaleFactor
 {
-    ResolutionSetting* res = [currentDocument.resolutions objectAtIndex:currentDocument.currentResolution];
+	if (currentDocument == nil)
+	{
+		return;
+	}
+
+	ResolutionSetting* res = [currentDocument.resolutions objectAtIndex:currentDocument.currentResolution];
 	
 	if([CCDirector sharedDirector].contentScaleFactor != res.scale)
     {


### PR DESCRIPTION
In AppDelegate.m -updatePositionScaleFactor depended on currentDocument being set but that is not the case after opening a project so it tried to set different scale factors with a value of 0 causing the crash due to assertions. This method is invoked anyways when a document is opened/selected so the guard statement causes no harm.
