### PR TITLE
Bugfix for issue #46 Deleting folder with Interface files nested underneath, and then saving.

### DIFF
--- a/SpriteBuilder/ccBuilder/AppDelegate.m
+++ b/SpriteBuilder/ccBuilder/AppDelegate.m
@@ -1717,15 +1717,21 @@ static BOOL hideAllToNextSeparator;
     return NULL;
 }
 
-- (NSTabViewItem*) tabViewItemFromPath:(NSString*)path
+// A path can be a folder not only a file. Set includeViewWithinFolderPath to YES to return
+// the first view that is within a given folder path
+- (NSTabViewItem *)tabViewItemFromPath:(NSString *)path includeViewWithinFolderPath:(BOOL)includeViewWithinFolderPath
 {
-    NSArray* items = [tabView tabViewItems];
-    for (int i = 0; i < [items count]; i++)
-    {
-        CCBDocument* doc = [(NSTabViewItem*)[items objectAtIndex:i] identifier];
-        if ([doc.fileName isEqualToString:path]) return [items objectAtIndex:i];
-    }
-    return NULL;
+	NSArray *items = [tabView tabViewItems];
+	for (NSUInteger i = 0; i < [items count]; i++)
+	{
+		CCBDocument *doc = [(NSTabViewItem *) [items objectAtIndex:i] identifier];
+		if ([doc.fileName isEqualToString:path]
+			|| (includeViewWithinFolderPath && [doc isWithinPath:path]))
+		{
+			return [items objectAtIndex:i];
+		}
+	}
+	return NULL;
 }
 
 - (void) checkForTooManyDirectoriesInCurrentDoc
@@ -3262,7 +3268,7 @@ static BOOL hideAllToNextSeparator;
 
 - (void) removedDocumentWithPath:(NSString*)path
 {
-    NSTabViewItem* item = [self tabViewItemFromPath:path];
+    NSTabViewItem* item = [self tabViewItemFromPath:path includeViewWithinFolderPath:YES];
     if (item)
     {
         [tabView removeTabViewItem:item];
@@ -3271,7 +3277,7 @@ static BOOL hideAllToNextSeparator;
 
 - (void) renamedDocumentPathFrom:(NSString*)oldPath to:(NSString*)newPath
 {
-    NSTabViewItem* item = [self tabViewItemFromPath:oldPath];
+    NSTabViewItem* item = [self tabViewItemFromPath:oldPath includeViewWithinFolderPath:NO];
     CCBDocument* doc = [item identifier];
     doc.fileName = newPath;
     [item setLabel:doc.formattedName];

--- a/SpriteBuilder/ccBuilder/CCBDocument.h
+++ b/SpriteBuilder/ccBuilder/CCBDocument.h
@@ -59,11 +59,15 @@
 @property (nonatomic,assign) float stageZoom;
 @property (nonatomic,assign) int stageColor;
 @property (nonatomic,readonly) NSString* rootPath;
-- (NSString*) formattedName;
 @property (nonatomic,strong) NSMutableArray* resolutions;
 @property (nonatomic,assign) int currentResolution;
 @property (nonatomic,strong) NSMutableArray* sequences;
 @property (nonatomic,assign) int currentSequenceId;
 @property (nonatomic,assign) int docDimensionsType;
 @property (nonatomic,assign) NSUInteger UUID;
+
+- (NSString*) formattedName;
+
+- (BOOL)isWithinPath:(NSString *)path;
+
 @end

--- a/SpriteBuilder/ccBuilder/CCBDocument.m
+++ b/SpriteBuilder/ccBuilder/CCBDocument.m
@@ -83,4 +83,9 @@
     }
 }
 
+- (BOOL)isWithinPath:(NSString *)path
+{
+	return [self.fileName hasPrefix:path];
+}
+
 @end


### PR DESCRIPTION
If a tab was open for a certain file and that file was deleted by deleting a parent folder the tab would be kept open. Saving now caused the crash since there was no valid currentDocument any more. Switching tabs causes the currentDocument to be updated and deleting a tab will select another (valid) tab.
Solution: Close the tab as soon as a file gets deleted by deleted parents.
