### PR TITLE
Fixing an issue with .psd files with effects in them.

### DIFF
--- a/SpriteBuilder/ccBuilder/ResourceManager.m
+++ b/SpriteBuilder/ccBuilder/ResourceManager.m
@@ -1029,8 +1029,10 @@
     // Save the image
     CFURLRef url = (__bridge CFURLRef)[NSURL fileURLWithPath:dstFile];
 		
-		CFStringRef out_type = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)([dstFile pathExtension]), NULL);
-    CGImageDestinationRef destination = CGImageDestinationCreateWithURL(url, out_type, 1, NULL);
+    // NOTE! Rescaled image is always saved as a PNG even if the output filename is .psd.
+    // ImageIO discovers format types from the file header and not the extension.
+    // However, later processing stages in the SB export process need the original filename to be preserved.
+    CGImageDestinationRef destination = CGImageDestinationCreateWithURL(url, kUTTypePNG, 1, NULL);
     CGImageDestinationAddImage(destination, imageDst, nil);
     
     if (!CGImageDestinationFinalize(destination)) {


### PR DESCRIPTION
The issue was that it was downscaling .psd files and saving them as .psd files. Now it saves the temporary downscaled image as a png file, but with the .psd extension. Later stages in the SB publishing steps need the filename to stay the same. ImageIO doesn't actually look at the extension anyway, so it's able to read the files correctly.

The temporary image is deleted in a later step before the publishing is complete.
