### PR TITLE
Fixed: Deleting wave files not possible #313

### DIFF
--- a/SpriteBuilder/ccBuilder/AppDelegate.m
+++ b/SpriteBuilder/ccBuilder/AppDelegate.m
@@ -2711,9 +2711,12 @@ static BOOL hideAllToNextSeparator;
 - (IBAction) delete:(id) sender
 {
     // First attempt to delete selected keyframes
-    if ([sequenceHandler deleteSelectedKeyframesForCurrentSequence]) return;
-    
-    // Then delete the selected node
+	if ([sequenceHandler deleteSelectedKeyframesForCurrentSequence])
+	{
+		return;
+	}
+
+	// Then delete the selected node
     NSArray* nodesToDelete = [NSArray arrayWithArray:self.selectedNodes];
     for (CCNode* node in nodesToDelete)
     {
@@ -4274,11 +4277,10 @@ static BOOL hideAllToNextSeparator;
 {
     int selectedRow = [sender tag];
     
-    if (selectedRow >= 0 && projectSettings)
+    if (projectSettings)
     {
         ResourceManagerOutlineView * resManagerOutlineView = (ResourceManagerOutlineView*)outlineProject;
-        
-        [resManagerOutlineView deleteSelectedResource];
+		[resManagerOutlineView deleteSelectedResourcesWithRightClickedRow:selectedRow];
     }
 }
 

--- a/SpriteBuilder/ccBuilder/ImageAndTextCell.m
+++ b/SpriteBuilder/ccBuilder/ImageAndTextCell.m
@@ -1,6 +1,6 @@
 /*
 	ImageAndTextCell.m
-	Copyright © 2006, Apple Computer, Inc., all rights reserved.
+	Copyright ï¿½ 2006, Apple Computer, Inc., all rights reserved.
 
 	Subclass of NSTextFieldCell which can display text and an image simultaneously.
 */
@@ -13,7 +13,7 @@
  redistribute this Apple software.
  
  In consideration of your agreement to abide by the following terms, and subject to these 
- terms, Apple grants you a personal, non-exclusive license, under AppleÕs copyrights in 
+ terms, Apple grants you a personal, non-exclusive license, under Appleï¿½s copyrights in 
  this original Apple software (the "Apple Software"), to use, reproduce, modify and 
  redistribute the Apple Software, with or without modifications, in source and/or binary 
  forms; provided that if you redistribute the Apple Software in its entirety and without 
@@ -46,7 +46,7 @@
 {
     self = [super init];
     if (!self) return NULL;
-    
+
     [self setFont:[NSFont systemFontOfSize:[NSFont smallSystemFontSize]]];
     
     return self;
@@ -108,33 +108,36 @@
 
 - (NSRect)imageAltFrameForCellFrame:(NSRect)cellFrame
 {
-    if (imageAlt != nil)
+	if (imageAlt != nil)
 	{
-        NSRect imageFrame;
-        imageFrame.size = [imageAlt size];
-        imageFrame.origin = cellFrame.origin;
-        imageFrame.origin.x += cellFrame.size.width - imageAlt.size.width + 3;
-        //imageFrame.origin.y += ceil((cellFrame.size.height - imageFrame.size.height) / 2);
-        
-        if ([self.controlView isFlipped])
-        {
-            imageFrame.origin.y += ceil((cellFrame.size.height + imageFrame.size.height) / 2);
-        }
-        else
-        {
-            imageFrame.origin.y += ceil((cellFrame.size.height - imageFrame.size.height) / 2);
-        }
-        
-        return imageFrame;
-    }
-    else
-        return NSZeroRect;
+		NSRect imageFrame;
+		imageFrame.size = [imageAlt size];
+		imageFrame.origin = cellFrame.origin;
+		imageFrame.origin.x += cellFrame.size.width - imageAlt.size.width + 3;
+
+		if ([self.controlView isFlipped])
+		{
+			imageFrame.origin.y += ceil((cellFrame.size.height + imageFrame.size.height) / 2);
+		}
+		else
+		{
+			imageFrame.origin.y += ceil((cellFrame.size.height - imageFrame.size.height) / 2);
+		}
+
+		return imageFrame;
+	}
+	else
+	{
+		return NSZeroRect;
+	}
 }
 
 - (void)editWithFrame:(NSRect)aRect inView:(NSView *)controlView editor:(NSText *)textObj delegate:(id)anObject event:(NSEvent *)theEvent
 {
     NSRect textFrame, imageFrame;
     NSDivideRect (aRect, &imageFrame, &textFrame, 3 + [image size].width, NSMinXEdge);
+	textFrame = NSInsetRect(textFrame, 0.0, 4.0);
+
     [super editWithFrame: textFrame inView: controlView editor:textObj delegate:anObject event: theEvent];
 }
 
@@ -142,7 +145,15 @@
 {
     NSRect textFrame, imageFrame;
     NSDivideRect (aRect, &imageFrame, &textFrame, 3 + [image size].width, NSMinXEdge);
+	textFrame = NSInsetRect(textFrame, 0.0, 4.0);
+
     [super selectWithFrame: textFrame inView: controlView editor:textObj delegate:anObject start:selStart length:selLength];
+}
+
+- (NSRect)drawingRectForBounds:(NSRect)theRect
+{
+	NSRect rectInset = NSInsetRect(theRect, 0.0, 4.0);
+	return [super drawingRectForBounds:rectInset];
 }
 
 - (void)drawWithFrame:(NSRect)cellFrame inView:(NSView *)controlView
@@ -156,8 +167,8 @@
         NSDivideRect(cellFrame, &imageFrame, &cellFrame, 3 + imageSize.width, NSMinXEdge);
         if ([self drawsBackground])
 		{
-            [[self backgroundColor] set];
-            NSRectFill(imageFrame);
+			[[self backgroundColor] set];
+			NSRectFill(cellFrame);
         }
         imageFrame.origin.x += 3;
         imageFrame.size = imageSize;
@@ -180,7 +191,7 @@
 - (NSSize)cellSize
 {
     NSSize cellSize = [super cellSize];
-    cellSize.width += (image ? [image size].width : 0) + 3;
+	cellSize.width += (image ? [image size].width : 0) + 3;
     return cellSize;
 }
 

--- a/SpriteBuilder/ccBuilder/ImageAndTextCell.m
+++ b/SpriteBuilder/ccBuilder/ImageAndTextCell.m
@@ -1,6 +1,6 @@
 /*
 	ImageAndTextCell.m
-	Copyright ï¿½ 2006, Apple Computer, Inc., all rights reserved.
+	Copyright © 2006, Apple Computer, Inc., all rights reserved.
 
 	Subclass of NSTextFieldCell which can display text and an image simultaneously.
 */
@@ -13,7 +13,7 @@
  redistribute this Apple software.
  
  In consideration of your agreement to abide by the following terms, and subject to these 
- terms, Apple grants you a personal, non-exclusive license, under Appleï¿½s copyrights in 
+ terms, Apple grants you a personal, non-exclusive license, under AppleÕs copyrights in 
  this original Apple software (the "Apple Software"), to use, reproduce, modify and 
  redistribute the Apple Software, with or without modifications, in source and/or binary 
  forms; provided that if you redistribute the Apple Software in its entirety and without 
@@ -46,7 +46,7 @@
 {
     self = [super init];
     if (!self) return NULL;
-
+    
     [self setFont:[NSFont systemFontOfSize:[NSFont smallSystemFontSize]]];
     
     return self;
@@ -108,36 +108,33 @@
 
 - (NSRect)imageAltFrameForCellFrame:(NSRect)cellFrame
 {
-	if (imageAlt != nil)
+    if (imageAlt != nil)
 	{
-		NSRect imageFrame;
-		imageFrame.size = [imageAlt size];
-		imageFrame.origin = cellFrame.origin;
-		imageFrame.origin.x += cellFrame.size.width - imageAlt.size.width + 3;
-
-		if ([self.controlView isFlipped])
-		{
-			imageFrame.origin.y += ceil((cellFrame.size.height + imageFrame.size.height) / 2);
-		}
-		else
-		{
-			imageFrame.origin.y += ceil((cellFrame.size.height - imageFrame.size.height) / 2);
-		}
-
-		return imageFrame;
-	}
-	else
-	{
-		return NSZeroRect;
-	}
+        NSRect imageFrame;
+        imageFrame.size = [imageAlt size];
+        imageFrame.origin = cellFrame.origin;
+        imageFrame.origin.x += cellFrame.size.width - imageAlt.size.width + 3;
+        //imageFrame.origin.y += ceil((cellFrame.size.height - imageFrame.size.height) / 2);
+        
+        if ([self.controlView isFlipped])
+        {
+            imageFrame.origin.y += ceil((cellFrame.size.height + imageFrame.size.height) / 2);
+        }
+        else
+        {
+            imageFrame.origin.y += ceil((cellFrame.size.height - imageFrame.size.height) / 2);
+        }
+        
+        return imageFrame;
+    }
+    else
+        return NSZeroRect;
 }
 
 - (void)editWithFrame:(NSRect)aRect inView:(NSView *)controlView editor:(NSText *)textObj delegate:(id)anObject event:(NSEvent *)theEvent
 {
     NSRect textFrame, imageFrame;
     NSDivideRect (aRect, &imageFrame, &textFrame, 3 + [image size].width, NSMinXEdge);
-	textFrame = NSInsetRect(textFrame, 0.0, 4.0);
-
     [super editWithFrame: textFrame inView: controlView editor:textObj delegate:anObject event: theEvent];
 }
 
@@ -145,15 +142,7 @@
 {
     NSRect textFrame, imageFrame;
     NSDivideRect (aRect, &imageFrame, &textFrame, 3 + [image size].width, NSMinXEdge);
-	textFrame = NSInsetRect(textFrame, 0.0, 4.0);
-
     [super selectWithFrame: textFrame inView: controlView editor:textObj delegate:anObject start:selStart length:selLength];
-}
-
-- (NSRect)drawingRectForBounds:(NSRect)theRect
-{
-	NSRect rectInset = NSInsetRect(theRect, 0.0, 4.0);
-	return [super drawingRectForBounds:rectInset];
 }
 
 - (void)drawWithFrame:(NSRect)cellFrame inView:(NSView *)controlView
@@ -167,8 +156,8 @@
         NSDivideRect(cellFrame, &imageFrame, &cellFrame, 3 + imageSize.width, NSMinXEdge);
         if ([self drawsBackground])
 		{
-			[[self backgroundColor] set];
-			NSRectFill(cellFrame);
+            [[self backgroundColor] set];
+            NSRectFill(imageFrame);
         }
         imageFrame.origin.x += 3;
         imageFrame.size = imageSize;
@@ -191,7 +180,7 @@
 - (NSSize)cellSize
 {
     NSSize cellSize = [super cellSize];
-	cellSize.width += (image ? [image size].width : 0) + 3;
+    cellSize.width += (image ? [image size].width : 0) + 3;
     return cellSize;
 }
 

--- a/SpriteBuilder/ccBuilder/ResourceManagerOutlineView.h
+++ b/SpriteBuilder/ccBuilder/ResourceManagerOutlineView.h
@@ -25,5 +25,5 @@
 #import "CCBOutlineView.h"
 
 @interface ResourceManagerOutlineView : CCBOutlineView
-- (void) deleteSelectedResource;
+- (void)deleteSelectedResourcesWithRightClickedRow:(NSInteger)rightClickedRowIndex;
 @end

--- a/SpriteBuilder/ccBuilder/en.lproj/MainMenu.xib
+++ b/SpriteBuilder/ccBuilder/en.lproj/MainMenu.xib
@@ -963,18 +963,18 @@ CA
                                                             <rect key="frame" x="0.0" y="239" width="250" height="401"/>
                                                             <autoresizingMask key="autoresizingMask"/>
                                                             <subviews>
-                                                                <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="18" horizontalPageScroll="10" verticalLineScroll="18" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="1498">
+                                                                <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="20" horizontalPageScroll="10" verticalLineScroll="20" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="1498">
                                                                     <rect key="frame" x="0.0" y="0.0" width="250" height="401"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                     <clipView key="contentView" copiesOnScroll="NO" id="xfY-vc-3Nd">
                                                                         <rect key="frame" x="0.0" y="0.0" width="250" height="401"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
-                                                                            <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" autosaveColumns="NO" rowHeight="16" indentationPerLevel="16" autoresizesOutlineColumn="YES" outlineTableColumn="1502" id="1499" customClass="ResourceManagerOutlineView">
+                                                                            <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="sourceList" autosaveColumns="NO" rowHeight="20" indentationPerLevel="14" outlineTableColumn="1502" id="1499" customClass="ResourceManagerOutlineView">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="250" height="401"/>
                                                                                 <autoresizingMask key="autoresizingMask"/>
-                                                                                <size key="intercellSpacing" width="3" height="2"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                <size key="intercellSpacing" width="3" height="0.0"/>
+                                                                                <color key="backgroundColor" name="_sourceListBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                                 <color key="gridColor" name="controlShadowColor" catalog="System" colorSpace="catalog"/>
                                                                                 <tableColumns>
                                                                                     <tableColumn width="240" minWidth="16" maxWidth="240" id="1502">
@@ -991,6 +991,9 @@ CA
                                                                                         <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                                                     </tableColumn>
                                                                                 </tableColumns>
+                                                                                <connections>
+                                                                                    <outlet property="menu" destination="1696" id="9j6-tR-0KV"/>
+                                                                                </connections>
                                                                             </outlineView>
                                                                         </subviews>
                                                                     </clipView>
@@ -1031,11 +1034,11 @@ CA
                                                                     <rect key="frame" x="-1" y="-1" width="251" height="452"/>
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                                                                     <clipView key="contentView" copiesOnScroll="NO" id="8K5-4q-KVz">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="251" height="452"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="236" height="437"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
-                                                                            <ikImageBrowserView autoresizesSubviews="NO" zoomValue="0.073521465063095093" constrainsToOriginalSize="YES" allowsMultipleSelection="NO" id="1986" customClass="CCBImageBrowserView">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="251" height="452"/>
+                                                                            <ikImageBrowserView autoresizesSubviews="NO" zoomValue="0.076471909880638123" constrainsToOriginalSize="YES" allowsMultipleSelection="NO" id="1986" customClass="CCBImageBrowserView">
+                                                                                <rect key="frame" x="0.0" y="0.0" width="236" height="437"/>
                                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                                 <ikCellsStyle key="cellsStyleMask" none="YES" titled="YES"/>
                                                                                 <autoresizingMask key="contentResizingMask" heightSizable="YES"/>
@@ -1709,11 +1712,11 @@ CA
                                                     <rect key="frame" x="0.0" y="0.0" width="298" height="657"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                     <clipView key="contentView" id="vCL-dY-h8s">
-                                                        <rect key="frame" x="0.0" y="0.0" width="298" height="657"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="283" height="642"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <subviews>
                                                             <view id="2046">
-                                                                <rect key="frame" x="0.0" y="0.0" width="298" height="657"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="283" height="642"/>
                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             </view>
                                                         </subviews>
@@ -1739,15 +1742,15 @@ CA
                                                     <rect key="frame" x="0.0" y="0.0" width="298" height="656"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" heightSizable="YES"/>
                                                     <clipView key="contentView" id="U4Z-Vf-EOq">
-                                                        <rect key="frame" x="0.0" y="0.0" width="298" height="656"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="283" height="641"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <subviews>
                                                             <view id="VWM-rZ-YR4">
-                                                                <rect key="frame" x="0.0" y="0.0" width="298" height="656"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="283" height="641"/>
                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                 <subviews>
                                                                     <button id="Gr1-tp-6dc">
-                                                                        <rect key="frame" x="7" y="634" width="149" height="20"/>
+                                                                        <rect key="frame" x="7" y="619" width="149" height="20"/>
                                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                         <buttonCell key="cell" type="check" title="Enable physics" bezelStyle="regularSquare" imagePosition="left" controlSize="small" state="on" inset="2" id="5IT-k9-mIz">
                                                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1763,7 +1766,7 @@ CA
                                                                         </connections>
                                                                     </button>
                                                                     <popUpButton verticalHuggingPriority="750" id="0Ex-EX-gU6">
-                                                                        <rect key="frame" x="87" y="604" width="205" height="22"/>
+                                                                        <rect key="frame" x="87" y="589" width="190" height="22"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                                         <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="YcA-X2-jqd">
                                                                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -1781,7 +1784,7 @@ CA
                                                                         </connections>
                                                                     </popUpButton>
                                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="Ro7-0f-xIv" customClass="CCBTextFieldLabel">
-                                                                        <rect key="frame" x="7" y="609" width="78" height="14"/>
+                                                                        <rect key="frame" x="7" y="594" width="78" height="14"/>
                                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Physics shape" id="Jde-yE-DxV">
                                                                             <font key="font" metaFont="smallSystem"/>
@@ -1793,7 +1796,7 @@ CA
                                                                         </connections>
                                                                     </textField>
                                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="ext-Gr-AoA" customClass="CCBTextFieldLabel">
-                                                                        <rect key="frame" x="7" y="510" width="44" height="14"/>
+                                                                        <rect key="frame" x="7" y="495" width="44" height="14"/>
                                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Density" id="hO5-Og-Qfj">
                                                                             <font key="font" metaFont="smallSystem"/>
@@ -1805,21 +1808,21 @@ CA
                                                                         </connections>
                                                                     </textField>
                                                                     <box autoresizesSubviews="NO" verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="a1T-Tl-JdY">
-                                                                        <rect key="frame" x="0.0" y="629" width="298" height="5"/>
+                                                                        <rect key="frame" x="0.0" y="614" width="283" height="5"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                                         <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
                                                                         <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                                                         <font key="titleFont" metaFont="system"/>
                                                                     </box>
                                                                     <box autoresizesSubviews="NO" verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="42d-Np-OMJ">
-                                                                        <rect key="frame" x="0.0" y="530" width="298" height="5"/>
+                                                                        <rect key="frame" x="0.0" y="515" width="283" height="5"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                                         <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
                                                                         <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                                                         <font key="titleFont" metaFont="system"/>
                                                                     </box>
                                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="PQS-eD-oNf" customClass="CCBTextFieldLabel">
-                                                                        <rect key="frame" x="7" y="587" width="77" height="14"/>
+                                                                        <rect key="frame" x="7" y="572" width="77" height="14"/>
                                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Corner radius" id="6vB-Jc-BlL">
                                                                             <font key="font" metaFont="smallSystem"/>
@@ -1831,7 +1834,7 @@ CA
                                                                         </connections>
                                                                     </textField>
                                                                     <textField verticalHuggingPriority="750" id="LAn-QT-8u4">
-                                                                        <rect key="frame" x="90" y="585" width="64" height="19"/>
+                                                                        <rect key="frame" x="90" y="570" width="64" height="19"/>
                                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="yYP-03-s7p">
                                                                             <numberFormatter key="formatter" formatterBehavior="custom10_4" positiveFormat="#,##0.###" negativeFormat="#,##0.###" localizesFormat="NO" numberStyle="decimal" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="1" maximumIntegerDigits="309" minimumFractionDigits="2" maximumFractionDigits="2" nilSymbol="           " id="frf-Ux-3PH">
@@ -1852,7 +1855,7 @@ CA
                                                                         </connections>
                                                                     </textField>
                                                                     <textField verticalHuggingPriority="750" id="WSz-ut-Vav">
-                                                                        <rect key="frame" x="90" y="508" width="64" height="19"/>
+                                                                        <rect key="frame" x="90" y="493" width="64" height="19"/>
                                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="AIF-qZ-QWA">
                                                                             <numberFormatter key="formatter" formatterBehavior="custom10_4" positiveFormat="#0.00" negativeFormat="#0.00" localizesFormat="NO" numberStyle="decimal" groupingSize="0" minimumIntegerDigits="1" maximumIntegerDigits="309" minimumFractionDigits="2" maximumFractionDigits="2" nilSymbol="           " id="s8k-Fr-05d">
@@ -1873,7 +1876,7 @@ CA
                                                                         </connections>
                                                                     </textField>
                                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="j37-bv-oYR" customClass="CCBTextFieldLabel">
-                                                                        <rect key="frame" x="7" y="488" width="45" height="14"/>
+                                                                        <rect key="frame" x="7" y="473" width="45" height="14"/>
                                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Friction" id="gnw-IR-keb">
                                                                             <font key="font" metaFont="smallSystem"/>
@@ -1885,7 +1888,7 @@ CA
                                                                         </connections>
                                                                     </textField>
                                                                     <textField verticalHuggingPriority="750" id="lwb-8F-FwC">
-                                                                        <rect key="frame" x="90" y="486" width="64" height="19"/>
+                                                                        <rect key="frame" x="90" y="471" width="64" height="19"/>
                                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="Ngd-b1-YHU">
                                                                             <numberFormatter key="formatter" formatterBehavior="custom10_4" positiveFormat="#0.00" negativeFormat="#0.00" numberStyle="decimal" groupingSize="0" minimumIntegerDigits="1" maximumIntegerDigits="309" minimumFractionDigits="2" maximumFractionDigits="2" nilSymbol="           " id="urP-Pl-E0K">
@@ -1906,7 +1909,7 @@ CA
                                                                         </connections>
                                                                     </textField>
                                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="Bg2-8I-Ea8" customClass="CCBTextFieldLabel">
-                                                                        <rect key="frame" x="7" y="466" width="51" height="14"/>
+                                                                        <rect key="frame" x="7" y="451" width="51" height="14"/>
                                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Elasticity" id="JHk-Kz-cSM">
                                                                             <font key="font" metaFont="smallSystem"/>
@@ -1918,7 +1921,7 @@ CA
                                                                         </connections>
                                                                     </textField>
                                                                     <textField verticalHuggingPriority="750" id="tmU-k8-xth">
-                                                                        <rect key="frame" x="90" y="464" width="64" height="19"/>
+                                                                        <rect key="frame" x="90" y="449" width="64" height="19"/>
                                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="kIE-o5-om9">
                                                                             <numberFormatter key="formatter" formatterBehavior="custom10_4" positiveFormat="#0.00" negativeFormat="#0.00" numberStyle="decimal" groupingSize="0" minimumIntegerDigits="1" maximumIntegerDigits="309" minimumFractionDigits="2" maximumFractionDigits="2" nilSymbol="           " id="W6b-Ic-ph1">
@@ -1939,7 +1942,7 @@ CA
                                                                         </connections>
                                                                     </textField>
                                                                     <matrix verticalHuggingPriority="750" allowsEmptySelection="NO" autorecalculatesCellSize="YES" id="OQY-uM-tEf">
-                                                                        <rect key="frame" x="8" y="541" width="79" height="38"/>
+                                                                        <rect key="frame" x="8" y="526" width="79" height="38"/>
                                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                         <size key="cellSize" width="68" height="18"/>
@@ -1966,7 +1969,7 @@ CA
                                                                         </connections>
                                                                     </matrix>
                                                                     <button id="EXb-j5-Wp1">
-                                                                        <rect key="frame" x="108" y="560" width="122" height="20"/>
+                                                                        <rect key="frame" x="108" y="545" width="122" height="20"/>
                                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                         <buttonCell key="cell" type="check" title="Affected by gravity" bezelStyle="regularSquare" imagePosition="left" controlSize="small" state="on" inset="2" id="QBb-KL-BpL">
                                                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -1986,7 +1989,7 @@ CA
                                                                         </connections>
                                                                     </button>
                                                                     <button id="c6C-i7-Duv">
-                                                                        <rect key="frame" x="108" y="540" width="103" height="20"/>
+                                                                        <rect key="frame" x="108" y="525" width="103" height="20"/>
                                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                         <buttonCell key="cell" type="check" title="Allows rotation" bezelStyle="regularSquare" imagePosition="left" controlSize="small" state="on" inset="2" id="Jer-o1-oe7">
                                                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -2014,10 +2017,10 @@ CA
                                                                     </binding>
                                                                     <binding destination="494" name="hidden2" keyPath="self.selectedNodeCanHavePhysics" previousBinding="SbN-x8-4tb" id="DrW-pi-MAh">
                                                                         <dictionary key="options">
-                                                                            <integer key="NSNullPlaceholder" value="-1"/>
+                                                                            <integer key="NSMultipleValuesPlaceholder" value="-1"/>
                                                                             <integer key="NSNotApplicablePlaceholder" value="-1"/>
                                                                             <integer key="NSNoSelectionPlaceholder" value="-1"/>
-                                                                            <integer key="NSMultipleValuesPlaceholder" value="-1"/>
+                                                                            <integer key="NSNullPlaceholder" value="-1"/>
                                                                             <string key="NSValueTransformerName">NSNegateBoolean</string>
                                                                         </dictionary>
                                                                     </binding>


### PR DESCRIPTION
Right click menu delete in resource view was limited to textures and folders only. Right clicking will highlight a row.

All resources can be deleted now with the right click option. Deletion works as follows: Right clicking will highlight a single item and delete it when it is outside a selected range of items. If the right click occurs outside a selction without a valid item the selection will be deleted. Behaves like in XCode's project navigator.
