### PR TITLE
SizeType set fix

### DIFF
--- a/SpriteBuilder/ccBuilder/PositionPropertySetter.m
+++ b/SpriteBuilder/ccBuilder/PositionPropertySetter.m
@@ -432,7 +432,7 @@
     {
         // Get absolute size
         CGSize oldSize = [PositionPropertySetter sizeForNode:node prop:prop];
-        CGSize absSize = [node convertContentSizeToPoints:oldSize type:node.contentSizeType];
+        CGSize absSize = [node convertContentSizeToPoints:oldSize type:[self sizeTypeForNode:node prop:prop]];
         
         [absSizes addObject:[NSValue valueWithSize:absSize]];
     }
@@ -446,7 +446,7 @@
     {
         // Calculate relative size for new type
         CGSize absSize = [[absSizes objectAtIndex:i] sizeValue];
-        CGSize newSize = [node convertContentSizeFromPoints:absSize type:node.contentSizeType];
+        CGSize newSize = [node convertContentSizeFromPoints:absSize type:[self sizeTypeForNode:node prop:prop]];
         
         [node setValue:[NSValue valueWithSize:newSize] forKey:prop];
         i++;


### PR DESCRIPTION
and also bug in cocos2d may be you can send this changes to them 

diff --git a/cocos2d/CCLabelTTF.m b/cocos2d/CCLabelTTF.m
index 46316ee..b31c9bd 100644
--- a/cocos2d/CCLabelTTF.m
+++ b/cocos2d/CCLabelTTF.m
@@ -488,7 +488,7 @@ static __strong NSMutableDictionary\* ccLabelTTF_registeredFonts;
     originalDimensions.width *= scale;
     originalDimensions.height *= scale;
-    CGSize dimensions = originalDimensions;
-    CGSize dimensions = [self convertContentSizeToPoints:originalDimensions type:_dimensionsType];
  
   float shadowBlurRadius = _shadowBlurRadius \* scale;
   CGPoint shadowOffset = ccpMult(self.shadowOffsetInPoints, scale); 
