### PR TITLE
Document path menu now showing when cmd+left click, ctrl+left click or right click.

### DIFF
--- a/SpriteBuilder/ccBuilder/AppDelegate.m
+++ b/SpriteBuilder/ccBuilder/AppDelegate.m
@@ -1978,6 +1978,8 @@ static BOOL hideAllToNextSeparator;
     Cocos2dUpdater *cocos2dUpdater = [[Cocos2dUpdater alloc] initWithAppDelegate:self projectSettings:projectSettings];
     [cocos2dUpdater updateAndBypassIgnore:NO];
 
+    self.window.representedFilename = fileName;
+
     return YES;
 }
 


### PR DESCRIPTION
Fixes: "Document window is missing drop down navigation title item #197"
