### PR TITLE
(post-beta) CCBXCocos2diPhoneWriter flag to prevent exporting any non-Spritekit properties

### DIFF
--- a/SpriteBuilder/Cocos2D iPhone/CCBXCocos2diPhoneWriter.h
+++ b/SpriteBuilder/Cocos2D iPhone/CCBXCocos2diPhoneWriter.h
@@ -57,6 +57,7 @@ enum {
     char temp[kCCBXTempBufferSize];
     int tempBit;
     int tempByte;
+	BOOL _exportingToSpriteKit;
 }
 
 @property (nonatomic,readonly) NSMutableData* data;


### PR DESCRIPTION
basically just adding a flag and adding "if (_exportingToSpriteKit == NO) ..." around physics related writer code
