### PR TITLE
Fixes issue with collisionCategories and collisionMasks being cleared

### DIFF
--- a/SpriteBuilder/ccBuilder/NodePhysicsBody.m
+++ b/SpriteBuilder/ccBuilder/NodePhysicsBody.m
@@ -105,6 +105,10 @@
 	{
 		_collisionCategories = [collisionCategoriesObject componentsSeparatedByString:@";"];
 	}
+    else if([collisionCategoriesObject isKindOfClass:[NSArray class]])
+    {
+        _collisionCategories = collisionCategoriesObject;
+    }
     
 	
 	id collisionMaskObject = [ser objectForKey:@"collisionMask"];
@@ -117,6 +121,10 @@
 	{
 		_collisionMask = [collisionMaskObject componentsSeparatedByString:@";"];
 	}
+    else if([collisionMaskObject isKindOfClass:[NSArray class]])
+    {
+        _collisionMask = collisionMaskObject;
+    }
     
     return self;
 }


### PR DESCRIPTION
- Fixes an issue where the collisionCategories and collisionMasks are cleared and never set again, after saving, if they are not a string

Bug report:
http://forum.spritebuilder.com/t/categories-and-masks-cleared-when-saving/963
https://github.com/spritebuilder/SpriteBuilder/issues/405
