### PR TITLE
Bugfix/#302 spritesheet previews not updated

### DIFF
--- a/SpriteBuilder/libs/Tupac/Tupac.mm
+++ b/SpriteBuilder/libs/Tupac/Tupac.mm
@@ -434,21 +434,7 @@ typedef struct _PVRTexHeader
         CFRelease(colorSpace);
     }
     
-    // Generate preview file
-    if (self.previewFile)
-    {
-        NSError *error;
-        if (![[NSFileManager defaultManager] removeItemAtPath:self.previewFile error:&error])
-        {
-            NSLog(@"[TEXTUREPACKER] Error removing preview image %@: %@", self.previewFile, error);
-        }
-
-        error = nil;
-        if (![[NSFileManager defaultManager] copyItemAtPath:pngFilename toPath:self.previewFile error:&error])
-        {
-            NSLog(@"[TEXTUREPACKER] Error copying preview image from %@ to %@: %@", pngFilename, self.previewFile, error);
-        }
-    }
+    [self generatePreviewImage:pngFilename];
 
     NSError * error = nil;
 
@@ -542,6 +528,24 @@ typedef struct _PVRTexHeader
         exit(EXIT_FAILURE);
     }
     return result;
+}
+
+- (void)generatePreviewImage:(NSString *)pngFilename
+{
+    if (self.previewFile)
+    {
+        NSError *error;
+        if (![[NSFileManager defaultManager] removeItemAtPath:self.previewFile error:&error])
+        {
+            NSLog(@"[TEXTUREPACKER] Error removing preview image %@: %@", self.previewFile, error);
+        }
+
+        error = nil;
+        if (![[NSFileManager defaultManager] copyItemAtPath:pngFilename toPath:self.previewFile error:&error])
+        {
+            NSLog(@"[TEXTUREPACKER] Error copying preview image from %@ to %@: %@", pngFilename, self.previewFile, error);
+        }
+    }
 }
 
 - (NSArray *) createTextureAtlasFromDirectoryPaths:(NSArray *)dirs

--- a/SpriteBuilder/libs/Tupac/Tupac.mm
+++ b/SpriteBuilder/libs/Tupac/Tupac.mm
@@ -434,14 +434,22 @@ typedef struct _PVRTexHeader
         CFRelease(colorSpace);
     }
     
+    // Generate preview file
     if (self.previewFile)
     {
-        // Generate preview file
-        [[NSFileManager defaultManager] copyItemAtPath:pngFilename toPath:self.previewFile error:NULL];
-    }
-    
+        NSError *error;
+        if (![[NSFileManager defaultManager] removeItemAtPath:self.previewFile error:&error])
+        {
+            NSLog(@"[TEXTUREPACKER] Error removing preview image %@: %@", self.previewFile, error);
+        }
 
-    
+        error = nil;
+        if (![[NSFileManager defaultManager] copyItemAtPath:pngFilename toPath:self.previewFile error:&error])
+        {
+            NSLog(@"[TEXTUREPACKER] Error copying preview image from %@ to %@: %@", pngFilename, self.previewFile, error);
+        }
+    }
+
     NSError * error = nil;
 
     self.formatConverter = [FCFormatConverter defaultConverter];


### PR DESCRIPTION
Existing preview images were not overwritten.
They will be deleted now before copying.
