### PR TITLE
Feature/#482 add gitignore default projects

### DIFF
--- a/Support/default_projects.gitignore
+++ b/Support/default_projects.gitignore
@@ -1,0 +1,34 @@
+# SpriteBuilder
+#
+*.ppng
+
+# Xcode
+#
+build/
+DerivedData
+xcuserdata
+!default.mode1v3
+!default.mode2v3
+!default.pbxuser
+!default.perspectivev3
+*.hmap
+*.ipa
+*.mode1v3
+*.mode2v3
+*.moved-aside
+*.pbxuser
+*.perspective
+*.perspectivev3
+*.swp
+*.xccheckout
+*.xcuserstate
+*~.nib
+.DS_Store
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
+#
+# Pods/

--- a/scripts/BuildDistribution.sh
+++ b/scripts/BuildDistribution.sh
@@ -17,21 +17,7 @@ CCB_DIR=$(pwd)
 rm -Rf build/
 rm -Rf SpriteBuilder/build/
 
-# Update version for about box
-echo "Version: $1" > Generated/Version.txt
-echo -n "GitHub: " >> Generated/Version.txt
-git rev-parse --short=10 HEAD >> Generated/Version.txt
-touch Generated/Version.txt
-
-# Copy cocos2d version file to generated
-cp SpriteBuilder/libs/cocos2d-iphone/VERSION Generated/cocos2d_version.txt
-
-# Generate default projects
-echo "=== GENERATING COCOS2D SB-PROJECT ==="
-bash scripts/GenerateTemplateProject.sh PROJECTNAME
-
-echo "=== GENERATING SPRITE KIT SB-PROJECT ==="
-bash scripts/GenerateTemplateProject.sh SPRITEKITPROJECTNAME
+./scripts/CreateAllGeneratedFiles.sh $1
 
 # Clean and build CocosBuilder
 echo "=== CLEANING PROJECT ==="

--- a/scripts/CreateAllGeneratedFiles.sh
+++ b/scripts/CreateAllGeneratedFiles.sh
@@ -1,0 +1,31 @@
+if [ "$#" -ne 1 ]; then
+    echo "Please provide the SpriteBuilder version"
+    exit 1
+fi
+
+if [ "$(basename "$(pwd)")" == "scripts" ]; then
+    cd ..
+fi
+
+if [ ! -d "SpriteBuilder" ]; then
+    echo "Please execute this script from within the SpriteBuilder's scripts folder"
+    exit 1
+fi
+
+# Update version for about box
+echo "Version: $1" > Generated/Version.txt
+echo -n "GitHub: " >> Generated/Version.txt
+git rev-parse --short=10 HEAD >> Generated/Version.txt
+echo "=== GENERATING SpriteBuilder version file ==="
+touch Generated/Version.txt
+
+# Copy cocos2d version file to generated
+echo "=== GENERATING COCOS2D version file ==="
+cp SpriteBuilder/libs/cocos2d-iphone/VERSION Generated/cocos2d_version.txt
+
+# Generate default projects
+echo "=== GENERATING COCOS2D SB-PROJECT ==="
+bash scripts/GenerateTemplateProject.sh PROJECTNAME
+
+echo "=== GENERATING SPRITE KIT SB-PROJECT ==="
+bash scripts/GenerateTemplateProject.sh SPRITEKITPROJECTNAME

--- a/scripts/GenerateTemplateProject.sh
+++ b/scripts/GenerateTemplateProject.sh
@@ -23,4 +23,10 @@ if [ -f ../../Generated/$PROJECTNAME.zip ]; then
 fi
 
 zip -q -r ../../Generated/$PROJECTNAME.zip * -x *.git* */tests/*
+
+# Adds default project .gitignore file to archive
+cp ../default_projects.gitignore ./.gitignore
+zip -q ../../Generated/$PROJECTNAME.zip .gitignore
+rm .gitignore
+
 echo ""


### PR DESCRIPTION
Moved the creation of generated files to a separate script `CreateAllGeneratedFiles.sh`. 
After pulling the most recent sources updating those files can now be done without building the whole project by executing:

```
./scripts/CreateAllGeneratedFiles.sh <SBVERSION>
```

Fixes https://github.com/spritebuilder/SpriteBuilder/issues/482
