### PR TITLE
A mandatory autoplayed timeline is not needed anymore.

### DIFF
--- a/SpriteBuilder/ccBuilder/SequencerSequence.m
+++ b/SpriteBuilder/ccBuilder/SequencerSequence.m
@@ -208,17 +208,10 @@
 
 - (void) setAutoPlay:(BOOL)ap
 {
-    if(autoPlay && !ap)
-        return;
-    
     if (ap)
     {
         [settingsWindow disableAutoPlayForAllItems];
     }
-    
-
-    
-    NSLog(@"setAutoPlay: %d", ap);
     autoPlay = ap;
 }
 

--- a/SpriteBuilder/ccBuilder/SequencerSettingsWindow.m
+++ b/SpriteBuilder/ccBuilder/SequencerSettingsWindow.m
@@ -55,19 +55,6 @@
         return NO;
     }
 
-    
-    if(![self.sequences findFirst:^BOOL(SequencerSequence * sequence, int idx) {
-        return sequence.autoPlay;
-    }])
-    {
-        // Display warning!
-        NSAlert* alert = [NSAlert alertWithMessageText:@"Missing Autoplay" defaultButton:@"OK" alternateButton:NULL otherButton:NULL informativeTextWithFormat:@"You need to have at least one timeline in your document marked as AutoPlay."];
-        [alert beginSheetModalForWindow:[self window] modalDelegate:NULL didEndSelector:NULL contextInfo:NULL];
-        
-        return NO;
-
-    }
-    
     return YES;
 }
 


### PR DESCRIPTION
Fixes https://github.com/spritebuilder/SpriteBuilder/issues/441
Tested on simulator, looks all good, just no animations being played.
