### PR TITLE
CCButton's label's alignment properties can now be set in the property inspector.

### DIFF
--- a/SpriteBuilder/CCButton/CCBPProperties.plist
+++ b/SpriteBuilder/CCButton/CCBPProperties.plist
@@ -516,6 +516,26 @@
 			<string>fontSize</string>
 		</dict>
 		<dict>
+			<key>displayName</key>
+			<string>Alignment</string>
+			<key>type</key>
+			<string>IntegerLabeled</string>
+			<key>name</key>
+			<string>horizontalAlignment</string>
+			<key>extra</key>
+			<string>Left|0|Center|1|Right|2</string>
+		</dict>
+		<dict>
+			<key>displayName</key>
+			<string></string>
+			<key>type</key>
+			<string>IntegerLabeled</string>
+			<key>name</key>
+			<string>verticalAlignment</string>
+			<key>extra</key>
+			<string>Top|0|Center|1|Bottom|2</string>
+		</dict>
+		<dict>
 			<key>default</key>
 			<array>
 				<integer>10</integer>


### PR DESCRIPTION
Second step to fix https://github.com/spritebuilder/SpriteBuilder/issues/192.

PLEASE DO NOT MERGE BEFORE
https://github.com/cocos2d/cocos2d-iphone/pull/765
is merge and SpriteBuilder's cocos2d submodule points to a revision including that commit.
