### PR TITLE
Update 9. Using Bitmap Fonts.md

### DIFF
--- a/Documentation/9. Using Bitmap Fonts.md
+++ b/Documentation/9. Using Bitmap Fonts.md
@@ -4,6 +4,6 @@ Bitmap fonts are much faster to render than truetype fonts. If you are updating 
 ## SpriteBuilder Font Format
 SpriteBuilder uses the bmfont format for bitmap fonts. A bmfont packages a set of png images and fnt files. These are the files that are actually loaded by Cocos2d. If you are using a font tool that hasn't built in support for SpriteBuilder fonts, you can easily package the png and fnt files manually.
 
-To manually package a bmfont, create a folder with the font name and the *.bmfont* extension. In the bmfont folder, create four sub-folders named *resources-phone*, *resources-phonehd*, *resources-tablet* and *resources-tablethd*. In each of these folder place the font that should be used for the corresponding resolution. The files need to be named exactly the same as the complete package (excluding the png and fnt extensions). See the image below for an example bmfont package:
+To manually package a bmfont, create a folder with the font name and the *.bmfont* extension (not *.bmFont* it's an error in the screenshot). In the bmfont folder, create four sub-folders named *resources-phone*, *resources-phonehd*, *resources-tablet* and *resources-tablethd*. In each of these folder place the font that should be used for the corresponding resolution. The files need to be named exactly the same as the complete package (excluding the png and fnt extensions). See the image below for an example bmfont package:
 
 ![image](bmfont-1.png?raw=true)


### PR DESCRIPTION
The extension is "bmfont" and not "bmFont". There is an error in the screenshot, so lot of people try with "bmFont" so they think the Bitmap Font feature doesn't work into SpriteBuilder.
