### PR TITLE
Scripts: Fixed scripts for paths with spaces

### DIFF
--- a/scripts/BuildDistribution.sh
+++ b/scripts/BuildDistribution.sh
@@ -8,7 +8,7 @@ CCB_VERSION=$1
 # Solution from: http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 #echo Script working directory: $SCRIPT_DIR
-cd $SCRIPT_DIR
+cd "$SCRIPT_DIR"
 
 # Remove build directory
 cd ..

--- a/scripts/GenerateTemplateProject.sh
+++ b/scripts/GenerateTemplateProject.sh
@@ -5,7 +5,7 @@ PROJECTNAME=$1
 # Change to the script's working directory no matter from where the script was called (except if there are symlinks used)
 # Solution from: http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd $SCRIPT_DIR
+cd "$SCRIPT_DIR"
 cd ../Support/$PROJECTNAME.spritebuilder/
 
 # Generate template project


### PR DESCRIPTION
Script for building the app doesn't work if path has spaces
