### PR TITLE
Fix for anchor points.

### DIFF
--- a/SpriteBuilder/ccBuilder/CCNode+NodeInfo.h
+++ b/SpriteBuilder/ccBuilder/CCNode+NodeInfo.h
@@ -42,10 +42,13 @@ NSString * kAnimationOfPhysicsWarning;
 @property (nonatomic,copy) NSString* displayName;
 @property (nonatomic,retain) NSMutableArray* customProperties;
 @property (nonatomic,readonly) CGPoint transformStartPosition;
-@property (nonatomic,assign) CGAffineTransform startTransform;
+@property (nonatomic,readonly) CGAffineTransform startTransform;
+@property (nonatomic,readonly) CGPoint startAnchorPoint;
 @property (nonatomic,retain) NodePhysicsBody* nodePhysicsBody;
 @property (nonatomic,assign) NSUInteger UUID;
 @property (nonatomic, readonly) BOOL hasKeyframes;
+
+- (void) cacheStartTransformAndAnchor;
 
 - (id) extraPropForKey:(NSString*)key;
 - (void) setExtraProp:(id)prop forKey:(NSString*)key;

--- a/SpriteBuilder/ccBuilder/CCNode+NodeInfo.m
+++ b/SpriteBuilder/ccBuilder/CCNode+NodeInfo.m
@@ -905,16 +905,23 @@ NSString * kAnimationOfPhysicsWarning = @"kAnimationOfPhysicsWarning";
     return info.startTransform;
 }
 
-- (void) setStartTransform:(CGAffineTransform)startTransform
-{
-    NodeInfo* info = self.userObject;
-    info.startTransform = startTransform;
-}
-
 - (CGPoint) transformStartPosition
 {
     NodeInfo* info = self.userObject;
     return CGPointApplyAffineTransform(self.anchorPointInPoints, info.startTransform);
+}
+
+- (CGPoint) startAnchorPoint
+{
+    NodeInfo* info = self.userObject;
+    return info.startAnchorPoint;
+}
+
+- (void) cacheStartTransformAndAnchor
+{
+    NodeInfo* info = self.userObject;
+    info.startTransform = self.nodeToWorldTransform;
+		info.startAnchorPoint = self.anchorPoint;
 }
 
 - (void) setUsesFlashSkew:(BOOL)seqExpanded

--- a/SpriteBuilder/ccBuilder/CocosScene.m
+++ b/SpriteBuilder/ccBuilder/CocosScene.m
@@ -1082,7 +1082,7 @@ static NSString * kZeroContentSizeImage = @"sel-round.png";
             
             // Transform anchor point
             currentMouseTransform = kCCBTransformHandleAnchorPoint;
-            transformScalingNode.startTransform = transformScalingNode.startTransform;
+            [transformScalingNode cacheStartTransformAndAnchor];
             return;
         }
         if(th == kCCBTransformHandleRotate && appDelegate.selectedNode != rootNode)
@@ -1306,7 +1306,7 @@ static NSString * kZeroContentSizeImage = @"sel-round.png";
             if(selectedNode.locked)
                 continue;
           
-            selectedNode.startTransform = selectedNode.nodeToWorldTransform;
+            [selectedNode cacheStartTransformAndAnchor];
         }
     
         if (appDelegate.selectedNode != rootNode &&
@@ -1617,7 +1617,7 @@ static NSString * kZeroContentSizeImage = @"sel-round.png";
         CGPoint deltaAnchorPoint = ccp(deltaLocal.x / transformScalingNode.contentSizeInPoints.width, deltaLocal.y / transformScalingNode.contentSizeInPoints.height);
         
         [appDelegate saveUndoStateWillChangeProperty:@"anchorPoint"];
-        transformScalingNode.anchorPoint = ccpAdd(transformScalingNode.transformStartPosition, deltaAnchorPoint);
+        transformScalingNode.anchorPoint = ccpAdd(transformScalingNode.startAnchorPoint, deltaAnchorPoint);
         [appDelegate refreshProperty:@"anchorPoint"];
         
         [self updateAnchorPointCompensation];

--- a/SpriteBuilder/ccBuilder/NodeInfo.h
+++ b/SpriteBuilder/ccBuilder/NodeInfo.h
@@ -44,6 +44,7 @@
 @property (nonatomic,copy) NSString* displayName;
 @property (nonatomic,strong) NSMutableArray* customProperties;
 @property (nonatomic,assign) CGAffineTransform startTransform;
+@property (nonatomic,assign) CGPoint startAnchorPoint;
 
 + (id) nodeInfoWithPlugIn:(PlugInNode*)pin;
 


### PR DESCRIPTION
This was broken when fixing snapping. NodeInfo was changed to store a full transform instead of just a start position. The startPosition property was also repurposed to hold the start anchor point before that.

NodeInfo now saves the anchor point in it's own property.
