### PR TITLE
Improve Texture Packing for Non-Square Sprite Sheets

### DIFF
--- a/SpriteBuilder/libs/Tupac/Tupac.mm
+++ b/SpriteBuilder/libs/Tupac/Tupac.mm
@@ -284,8 +284,10 @@ typedef struct _PVRTexHeader
         makeSquare = YES;
         outH = outW;
     }
+    
     BOOL allFitted = NO;
-    while (outW <= self.maxTextureSize && !allFitted)
+    BOOL packingError = NO;
+    while (!packingError && !allFitted)
     {
         MaxRectsBinPack bin(outW, outH);
         
@@ -312,24 +314,25 @@ typedef struct _PVRTexHeader
         }
         else
         {
-            outH *= 2;
-            
             if (makeSquare)
             {
-                outW = outH;
+                outW *= 2;
+                outH *= 2;
             }
             else
             {
-                if (outH > self.maxTextureSize)
-                {
-                    outH = 8;
+                if (outW > outH)
+                    outH *= 2;
+                else
                     outW *= 2;
-                }
             }
+            
+            if (outW > self.maxTextureSize)
+                packingError = YES;
         }
     }
     
-    if (!allFitted)
+    if (packingError)
     {
         [self setErrorMessage:@"Failed to fit all sprites in smart sprite sheet."];
     }


### PR DESCRIPTION
Resize width and height alternatively while packing images into
non-square sprite sheets
