### PR TITLE
Bugfix: Github issue #649.

### DIFF
--- a/SpriteBuilder/ccBuilder/CCBPublisher.m
+++ b/SpriteBuilder/ccBuilder/CCBPublisher.m
@@ -47,6 +47,7 @@
 #import "PublishSpriteKitSpriteSheetOperation.h"
 #import "PublishingTaskStatusProgress.h"
 #import "PublishLogging.h"
+#import "MiscConstants.h"
 
 @interface CCBPublisher ()
 
@@ -95,11 +96,15 @@
     return self;
 }
 
-- (BOOL)publishImageForResolutions:(NSString *)srcFile to:(NSString *)dstFile isSpriteSheet:(BOOL)isSpriteSheet outDir:(NSString *)outDir
+- (BOOL)publishImageForResolutions:(NSString *)srcFile
+                                to:(NSString *)dstFile
+                     isSpriteSheet:(BOOL)isSpriteSheet
+                            outDir:(NSString *)outDir
+                        fileLookup:(id <PublishFileLookupProtocol>)fileLookup
 {
     for (NSString* resolution in _publishForResolutions)
     {
-        [self publishImageFile:srcFile to:dstFile isSpriteSheet:isSpriteSheet outputDir:outDir resolution:resolution];
+        [self publishImageFile:srcFile to:dstFile isSpriteSheet:isSpriteSheet outputDir:outDir resolution:resolution fileLookup:fileLookup];
 	}
 
     return YES;
@@ -110,6 +115,7 @@
            isSpriteSheet:(BOOL)isSpriteSheet
                outputDir:(NSString *)outputDir
               resolution:(NSString *)resolution
+              fileLookup:(id<PublishFileLookupProtocol>)fileLookup
 {
     PublishImageOperation *operation = [[PublishImageOperation alloc] initWithProjectSettings:_projectSettings
                                                                                      warnings:_warnings
@@ -123,7 +129,7 @@
     operation.targetType = _targetType;
     operation.modifiedFileDateCache = _modifiedDatesCache;
     operation.publishedPNGFiles = _publishedPNGFiles;
-    operation.fileLookup = _renamedFilesLookup;
+    operation.fileLookup = fileLookup;
 
     [_publishingQueue addOperation:operation];
     return YES;
@@ -204,7 +210,7 @@
         [self publishSpriteKitAtlasDir:[outputDir stringByDeletingLastPathComponent]
                              sheetName:[outputDir lastPathComponent]
                                subPath:subPath
-                            publishDir:publishDirectory
+                      publishDirectory:publishDirectory
                              outputDir:outputDir];
     }
     else
@@ -274,7 +280,8 @@
 {
     // Skip non png files for generated sprite sheets
     if (isGeneratedSpriteSheet
-        && ![fileName isSmartSpriteSheetCompatibleFile])
+        && ![fileName isSmartSpriteSheetCompatibleFile]
+        && ![fileName isIntermediateFileLookup])
     {
         [_warnings addWarningWithDescription:[NSString stringWithFormat:@"Non-png|psd file in smart sprite sheet found (%@)", [fileName lastPathComponent]] isFatal:NO relatedFile:subPath];
         return YES;
@@ -288,7 +295,7 @@
         if (!isGeneratedSpriteSheet
             && ([fileName isSmartSpriteSheetCompatibleFile]))
         {
-            [self publishImageForResolutions:filePath to:dstFilePath isSpriteSheet:isGeneratedSpriteSheet outDir:outputDir];
+            [self publishImageForResolutions:filePath to:dstFilePath isSpriteSheet:isGeneratedSpriteSheet outDir:outputDir fileLookup:_renamedFilesLookup];
         }
         else if ([fileName isWaveSoundFile])
         {
@@ -414,7 +421,7 @@
                       subPath:(NSString *)subPath
                     outputDir:(NSString *)outputDir
 {
-    // NOTE: For every spritesheet one shared dir is used, so have to remove it on the
+    // NOTE: For every spritesheet one shared dir is used, so we have to remove it on the
     // queue to ensure that later spritesheets don't add more sprites from previous passes
     [_publishingQueue addOperationWithBlock:^
     {
@@ -432,29 +439,56 @@
 	{
 		NSString *spriteSheetFile = [[spriteSheetDir stringByAppendingPathComponent:[NSString stringWithFormat:@"resources-%@", resolution]] stringByAppendingPathComponent:spriteSheetName];
 
+        NSString *intermediateFileLookupPath = [publishDirectory  stringByAppendingPathComponent:INTERMEDIATE_FILE_LOOKUP_NAME];
+        [_renamedFilesLookup addIntermediateLookupPath:intermediateFileLookupPath];
+
 		if ([self spriteSheetExistsAndUpToDate:srcSpriteSheetDate spriteSheetFile:spriteSheetFile subPath:subPath])
 		{
             LocalLog(@"[SPRITESHEET] SKIPPING exists and up to date - file name: %@, subpath: %@, resolution: %@, file path: %@", [spriteSheetFile lastPathComponent], subPath, resolution, spriteSheetFile);
 			continue;
 		}
 
-        [self prepareImagesForSpriteSheetPublishing:publishDirectory outputDir:outputDir resolution:resolution];
+        // Note: these lookups are written as intermediate products to generate the final fileLookup.plist
+        PublishIntermediateFilesLookup *publishIntermediateFilesLookup = [[PublishIntermediateFilesLookup alloc] initWithFlattenPaths:_projectSettings.flattenPaths];
 
-        PublishSpriteSheetOperation *operation = [[PublishSpriteSheetOperation alloc] initWithProjectSettings:_projectSettings
-                                                                                                     warnings:_warnings
-                                                                                               statusProgress:_publishingTaskStatusProgress];
-        operation.publishDirectory = publishDirectory;
-        operation.publishedPNGFiles = _publishedPNGFiles;
-        operation.srcSpriteSheetDate = srcSpriteSheetDate;
-        operation.resolution = resolution;
-        operation.srcDirs = @[[_projectSettings.tempSpriteSheetCacheDirectory stringByAppendingPathComponent:[NSString stringWithFormat:@"resources-%@", resolution]],
-                              _projectSettings.tempSpriteSheetCacheDirectory];
-        operation.spriteSheetFile = spriteSheetFile;
-        operation.subPath = subPath;
-        operation.targetType = _targetType;
+        [self prepareImagesForSpriteSheetPublishing:publishDirectory
+                                          outputDir:outputDir
+                                         resolution:resolution
+                                         fileLookup:publishIntermediateFilesLookup];
+
+        PublishSpriteSheetOperation *operation = [self createSpriteSheetOperation:publishDirectory
+                                                                          subPath:subPath
+                                                               srcSpriteSheetDate:srcSpriteSheetDate
+                                                                       resolution:resolution
+                                                                  spriteSheetFile:spriteSheetFile];
 
         [_publishingQueue addOperation:operation];
+
+        [_publishingQueue addOperationWithBlock:^{
+            if (![publishIntermediateFilesLookup writeToFile:intermediateFileLookupPath])
+            {
+                [_warnings addWarningWithDescription:[NSString stringWithFormat:@"Could not write intermediate file lookup for smart spritesheet %@ @ %@", spriteSheetName, resolution]];
+            }
+        }];
 	}
+}
+
+- (PublishSpriteSheetOperation *)createSpriteSheetOperation:(NSString *)publishDirectory subPath:(NSString *)subPath srcSpriteSheetDate:(NSDate *)srcSpriteSheetDate resolution:(NSString *)resolution spriteSheetFile:(NSString *)spriteSheetFile
+{
+    PublishSpriteSheetOperation *operation = [[PublishSpriteSheetOperation alloc] initWithProjectSettings:_projectSettings
+                                                                                                 warnings:_warnings
+                                                                                           statusProgress:_publishingTaskStatusProgress];
+    operation.publishDirectory = publishDirectory;
+    operation.publishedPNGFiles = _publishedPNGFiles;
+    operation.srcSpriteSheetDate = srcSpriteSheetDate;
+    operation.resolution = resolution;
+    operation.srcDirs = @[
+            [_projectSettings.tempSpriteSheetCacheDirectory stringByAppendingPathComponent:[NSString stringWithFormat:@"resources-%@", resolution]],
+            _projectSettings.tempSpriteSheetCacheDirectory];
+    operation.spriteSheetFile = spriteSheetFile;
+    operation.subPath = subPath;
+    operation.targetType = _targetType;
+    return operation;
 }
 
 - (BOOL)spriteSheetExistsAndUpToDate:(NSDate *)srcSpriteSheetDate spriteSheetFile:(NSString *)spriteSheetFile subPath:(NSString *)subPath
@@ -466,7 +500,10 @@
             && !isDirty;
 }
 
-- (void)prepareImagesForSpriteSheetPublishing:(NSString *)publishDirectory outputDir:(NSString *)outputDir resolution:(NSString *)resolution
+- (void)prepareImagesForSpriteSheetPublishing:(NSString *)publishDirectory
+                                    outputDir:(NSString *)outputDir
+                                   resolution:(NSString *)resolution
+                                   fileLookup:(id<PublishFileLookupProtocol>)fileLookup
 {
     NSFileManager *fileManager = [NSFileManager defaultManager];
 
@@ -486,7 +523,8 @@
                                 to:dstFile
                      isSpriteSheet:NO
                          outputDir:outputDir
-                        resolution:resolution];
+                        resolution:resolution
+                        fileLookup:fileLookup];
         }
     }
 }
@@ -494,7 +532,7 @@
 - (void)publishSpriteKitAtlasDir:(NSString *)spriteSheetDir
                        sheetName:(NSString *)spriteSheetName
                          subPath:(NSString *)subPath
-                      publishDir:(NSString *)publishDir
+                publishDirectory:(NSString *)publishDirectory
                        outputDir:(NSString *)outputDir
 {
     NSFileManager *fileManager = [NSFileManager defaultManager];
@@ -512,19 +550,44 @@
 	
 	for (NSString* resolution in _publishForResolutions)
 	{
-        [self prepareImagesForSpriteSheetPublishing:publishDir outputDir:outputDir resolution:resolution];
+        NSString *intermediateFileLookupPath = [publishDirectory stringByAppendingPathComponent:INTERMEDIATE_FILE_LOOKUP_NAME];
+        [_renamedFilesLookup addIntermediateLookupPath:intermediateFileLookupPath];
 
-        PublishSpriteKitSpriteSheetOperation *operation = [[PublishSpriteKitSpriteSheetOperation alloc] initWithProjectSettings:_projectSettings
-                                                                                                     warnings:_warnings
-                                                                                               statusProgress:_publishingTaskStatusProgress];
-        operation.resolution = resolution;
-        operation.spriteSheetDir = spriteSheetDir;
-        operation.spriteSheetName = spriteSheetName;
-        operation.subPath = subPath;
-        operation.textureAtlasToolFilePath = textureAtlasToolLocation;
+        // Note: these lookups are written as intermediate products to generate the final fileLookup.plist
+        PublishIntermediateFilesLookup *publishIntermediateFilesLookup = [[PublishIntermediateFilesLookup alloc] initWithFlattenPaths:_projectSettings.flattenPaths];
 
+        [self prepareImagesForSpriteSheetPublishing:publishDirectory
+                                          outputDir:outputDir
+                                         resolution:resolution
+                                         fileLookup:publishIntermediateFilesLookup];
+
+        PublishSpriteKitSpriteSheetOperation *operation = [self createSpriteKitSheetOperation:spriteSheetDir
+                                                                              spriteSheetName:spriteSheetName
+                                                                                      subPath:subPath
+                                                                     textureAtlasToolLocation:textureAtlasToolLocation
+                                                                                   resolution:resolution];
         [_publishingQueue addOperation:operation];
+
+        [_publishingQueue addOperationWithBlock:^{
+            if (![publishIntermediateFilesLookup writeToFile:intermediateFileLookupPath])
+            {
+                [_warnings addWarningWithDescription:[NSString stringWithFormat:@"Could not write intermediate file lookup for smart spritesheet %@ @ %@", spriteSheetName, resolution]];
+            }
+        }];
     }
+}
+
+- (PublishSpriteKitSpriteSheetOperation *)createSpriteKitSheetOperation:(NSString *)spriteSheetDir spriteSheetName:(NSString *)spriteSheetName subPath:(NSString *)subPath textureAtlasToolLocation:(NSString *)textureAtlasToolLocation resolution:(NSString *)resolution
+{
+    PublishSpriteKitSpriteSheetOperation *operation = [[PublishSpriteKitSpriteSheetOperation alloc] initWithProjectSettings:_projectSettings
+                                                                                                                   warnings:_warnings
+                                                                                                             statusProgress:_publishingTaskStatusProgress];
+    operation.resolution = resolution;
+    operation.spriteSheetDir = spriteSheetDir;
+    operation.spriteSheetName = spriteSheetName;
+    operation.subPath = subPath;
+    operation.textureAtlasToolFilePath = textureAtlasToolLocation;
+    return operation;
 }
 
 - (void)publishGeneratedFiles

--- a/SpriteBuilder/ccBuilder/MiscConstants.h
+++ b/SpriteBuilder/ccBuilder/MiscConstants.h
@@ -1,3 +1,5 @@
 extern NSString *const PACKAGE_NAME_SUFFIX;
 
 extern NSString *const PACKAGES_FOLDER_NAME;
+
+extern NSString *const INTERMEDIATE_FILE_LOOKUP_NAME;

--- a/SpriteBuilder/ccBuilder/MiscConstants.m
+++ b/SpriteBuilder/ccBuilder/MiscConstants.m
@@ -1,3 +1,5 @@
 NSString *const PACKAGE_NAME_SUFFIX = @"sbpack";
 
 NSString *const PACKAGES_FOLDER_NAME = @"packages";
+
+NSString *const INTERMEDIATE_FILE_LOOKUP_NAME = @"intermediateFileLookup.plist";

--- a/SpriteBuilder/ccBuilder/NSString+Publishing.h
+++ b/SpriteBuilder/ccBuilder/NSString+Publishing.h
@@ -12,6 +12,8 @@
 
 - (BOOL)isWaveSoundFile;
 
+- (BOOL)isIntermediateFileLookup;
+
 // Tests if the file has a spritesheet compatible extension (e.g. psd and png)
 - (BOOL)isSmartSpriteSheetCompatibleFile;
 

--- a/SpriteBuilder/ccBuilder/NSString+Publishing.m
+++ b/SpriteBuilder/ccBuilder/NSString+Publishing.m
@@ -1,6 +1,7 @@
 #import "NSString+Publishing.h"
 #import "CCBFileUtil.h"
 #import "ResourceManager.h"
+#import "MiscConstants.h"
 
 
 @implementation NSString (Publishing)
@@ -25,6 +26,11 @@
 {
     NSString *extension = [[self pathExtension] lowercaseString];
     return [extension isEqualToString:@"wav"];
+}
+
+- (BOOL)isIntermediateFileLookup
+{
+    return [[self lastPathComponent] isEqualToString:INTERMEDIATE_FILE_LOOKUP_NAME];
 }
 
 - (BOOL)isSmartSpriteSheetCompatibleFile

--- a/SpriteBuilder/ccBuilder/ProjectSettings.m
+++ b/SpriteBuilder/ccBuilder/ProjectSettings.m
@@ -34,6 +34,7 @@
 #import "SBErrors.h"
 #import "ResourceTypes.h"
 #import "NSError+SBErrors.h"
+#import "MiscConstants.h"
 
 #import <ApplicationServices/ApplicationServices.h>
 
@@ -367,10 +368,26 @@
     NSAssert(res.type == kCCBResTypeDirectory, @"Resource must be directory");
     
     [self removeObjectForResource:res andKey:@"isSmartSpriteSheet"];
-    
+
+    [self removeIntermediateFileLookupFile:res];
+
     [self store];
     [[ResourceManager sharedManager] notifyResourceObserversResourceListUpdated];
     [[AppDelegate appDelegate].projectOutlineHandler updateSelectionPreview];
+}
+
+- (void)removeIntermediateFileLookupFile:(RMResource *)res
+{
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSString *intermediateFileLookup = [res.filePath stringByAppendingPathComponent:INTERMEDIATE_FILE_LOOKUP_NAME];
+    if ([fileManager fileExistsAtPath:intermediateFileLookup])
+    {
+        NSError *error;
+        if (![fileManager removeItemAtPath:intermediateFileLookup error:&error])
+        {
+            NSLog(@"Error removing intermediate filelookup file %@ - %@", intermediateFileLookup, error);
+        }
+    }
 }
 
 - (void) setValue:(id) val forResource:(RMResource*) res andKey:(id) key

--- a/SpriteBuilder/ccBuilder/PublishGeneratedFilesOperation.m
+++ b/SpriteBuilder/ccBuilder/PublishGeneratedFilesOperation.m
@@ -96,7 +96,10 @@
 
 - (void)generateFileLookup
 {
-    [_fileLookup writeToFileAtomically:[_outputDir stringByAppendingPathComponent:@"fileLookup.plist"]];
+    if (![_fileLookup writeToFileAtomically:[_outputDir stringByAppendingPathComponent:@"fileLookup.plist"]])
+    {
+        [_warnings addWarningWithDescription:@"Could not write fileLookup.plist."];
+    }
 }
 
 - (NSString *)description

--- a/SpriteBuilder/ccBuilder/PublishImageOperation.h
+++ b/SpriteBuilder/ccBuilder/PublishImageOperation.h
@@ -6,6 +6,7 @@
 @class CCBPublisher;
 @class FCFormatConverter;
 @class PublishRenamedFilesLookup;
+@protocol PublishFileLookupProtocol;
 
 @interface PublishImageOperation : PublishBaseOperation
 
@@ -15,7 +16,7 @@
 @property (nonatomic, copy) NSString *resolution;
 
 @property (nonatomic, strong) NSMutableSet *publishedPNGFiles;
-@property (nonatomic, strong) PublishRenamedFilesLookup *fileLookup;
+@property (nonatomic, strong) id<PublishFileLookupProtocol> fileLookup;
 
 @property (nonatomic) BOOL isSpriteSheet;
 @property (nonatomic) CCBPublisherTargetType targetType;

--- a/SpriteBuilder/ccBuilder/PublishImageOperation.m
+++ b/SpriteBuilder/ccBuilder/PublishImageOperation.m
@@ -16,6 +16,10 @@
 
 @property (nonatomic, strong) FCFormatConverter *formatConverter;
 
+@property (nonatomic) int format;
+@property (nonatomic) BOOL dither;
+@property (nonatomic) BOOL compress;
+
 @end
 
 
@@ -34,23 +38,28 @@
 
 - (void)assertProperties
 {
-    NSAssert(_srcFilePath != nil, @"srcPath should not be nil");
-    NSAssert(_dstFilePath != nil, @"dstPath should not be nil");
-    NSAssert(_outputDir != nil, @"outDir should not be nil");
-    NSAssert(_resolution != nil, @"resolution should not be nil");
-    NSAssert(_publishedPNGFiles != nil, @"publishedPNGFiles should not be nil");
-    NSAssert(_fileLookup != nil, @"fileLookup should not be nil");
+    NSAssert(_srcFilePath != nil, @"srcPath must not be nil");
+    NSAssert(_dstFilePath != nil, @"dstPath must not be nil");
+    NSAssert(_outputDir != nil, @"outDir must not be nil");
+    NSAssert(_resolution != nil, @"resolution must not be nil");
+    NSAssert(_publishedPNGFiles != nil, @"publishedPNGFiles must not be nil");
+    NSAssert(_fileLookup != nil, @"lookup must not be nil");
 }
 
+// TODO: this is a long method -> split up!
 - (void)publishImage
 {
-    // TODO: this is a long method -> split up!
     NSString *relPath = [ResourceManagerUtil relativePathFromAbsolutePath:_srcFilePath];
+
+    [self setFormatDitherAndCompress:relPath];
+
+    // Note: always do this, filelookup is created everytime from scratch
+    [self addRenamingRuleToFileLookup:relPath];
 
     if (_isSpriteSheet
         && [self isSpriteSheetAlreadyPublished:_srcFilePath outDir:_outputDir resolution:_resolution])
     {
-        LocalLog(@"[%@] SKIPPING spritesheet and already published - %@", [self class], [self description]);
+        LocalLog(@"[%@] SKIPPING spritesheet is already published - %@", [self class], [self description]);
         return;
     }
 
@@ -81,41 +90,11 @@
     // Create destination directory if it doesn't exist
     [fileManager createDirectoryAtPath:dstDir withIntermediateDirectories:YES attributes:NULL error:NULL];
 
-    // Get the format of the published image
-    int format = kFCImageFormatPNG;
-    BOOL dither = NO;
-    BOOL compress = NO;
-
-    // TODO: Move to data object: format, dither, compress
-    if (!_isSpriteSheet)
-    {
-        if (_targetType == kCCBPublisherTargetTypeIPhone)
-        {
-            format = [[_projectSettings valueForRelPath:relPath andKey:@"format_ios"] intValue];
-            dither = [[_projectSettings valueForRelPath:relPath andKey:@"format_ios_dither"] boolValue];
-            compress = [[_projectSettings valueForRelPath:relPath andKey:@"format_ios_compress"] boolValue];
-        }
-        else if (_targetType == kCCBPublisherTargetTypeAndroid)
-        {
-            format = [[_projectSettings valueForRelPath:relPath andKey:@"format_android"] intValue];
-            dither = [[_projectSettings valueForRelPath:relPath andKey:@"format_android_dither"] boolValue];
-            compress = [[_projectSettings valueForRelPath:relPath andKey:@"format_android_compress"] boolValue];
-        }
-    }
-
     // Fetch new name
     NSString *dstPathProposal = [[FCFormatConverter defaultConverter] proposedNameForConvertedImageAtPath:_dstFilePath
-                                                                                                   format:format
-                                                                                                 compress:compress
+                                                                                                   format:_format
+                                                                                                 compress:_compress
                                                                                             isSpriteSheet:_isSpriteSheet];
-
-    // Add renaming rule
-    NSString *relPathRenamed = [[FCFormatConverter defaultConverter] proposedNameForConvertedImageAtPath:relPath
-                                                                                                  format:format
-                                                                                                compress:compress
-                                                                                           isSpriteSheet:_isSpriteSheet];
-
-    [_fileLookup addRenamingRuleFrom:relPath to:relPathRenamed];
 
     // Copy and convert the image
     BOOL isDirty = [_projectSettings isDirtyRelPath:relPath];
@@ -145,9 +124,9 @@
 
         self.formatConverter = [FCFormatConverter defaultConverter];
         if (![_formatConverter convertImageAtPath:_dstFilePath
-                                           format:format
-                                           dither:dither
-                                         compress:compress
+                                           format:_format
+                                           dither:_dither
+                                         compress:_compress
                                     isSpriteSheet:_isSpriteSheet
                                    outputFilename:&dstPathConverted
                                             error:&error])
@@ -163,7 +142,7 @@
         [CCBFileUtil setModificationDate:srcDate forFile:dstPathConverted];
 
         if (!_isSpriteSheet
-            && format == kFCImageFormatPNG)
+            && _format == kFCImageFormatPNG)
         {
             [_publishedPNGFiles addObject:dstPathConverted];
         }
@@ -193,9 +172,9 @@
 
         self.formatConverter = [FCFormatConverter defaultConverter];
         if (![_formatConverter convertImageAtPath:_dstFilePath
-                                           format:format
-                                           dither:dither
-                                         compress:compress
+                                           format:_format
+                                           dither:_dither
+                                         compress:_compress
                                     isSpriteSheet:_isSpriteSheet
                                    outputFilename:&dstPathConverted
                                             error:&error])
@@ -209,7 +188,7 @@
         [CCBFileUtil setModificationDate:srcDate forFile:dstPathConverted];
 
         if (!_isSpriteSheet
-            && format == kFCImageFormatPNG)
+            && _format == kFCImageFormatPNG)
         {
             [_publishedPNGFiles addObject:dstPathConverted];
         }
@@ -217,6 +196,39 @@
     else
     {
         [_warnings addWarningWithDescription:[NSString stringWithFormat:@"Failed to publish file %@, make sure it is in the resources-auto folder.", srcFileName] isFatal:NO];
+    }
+}
+
+- (void)addRenamingRuleToFileLookup:(NSString *)relPath
+{
+    NSString *relPathRenamed = [[FCFormatConverter defaultConverter] proposedNameForConvertedImageAtPath:relPath
+                                                                                                  format:_format
+                                                                                                compress:_compress
+                                                                                           isSpriteSheet:_isSpriteSheet];
+    [_fileLookup addRenamingRuleFrom:relPath to:relPathRenamed];
+}
+
+- (void)setFormatDitherAndCompress:(NSString *)relPath
+{
+    self.format = kFCImageFormatPNG;
+    self.dither = NO;
+    self.compress = NO;
+
+    // TODO: Move to data object: format, dither, compress
+    if (!_isSpriteSheet)
+    {
+        if (_targetType == kCCBPublisherTargetTypeIPhone)
+        {
+            self.format = [[_projectSettings valueForRelPath:relPath andKey:@"format_ios"] intValue];
+            self.dither = [[_projectSettings valueForRelPath:relPath andKey:@"format_ios_dither"] boolValue];
+            self.compress = [[_projectSettings valueForRelPath:relPath andKey:@"format_ios_compress"] boolValue];
+        }
+        else if (_targetType == kCCBPublisherTargetTypeAndroid)
+        {
+            self.format = [[_projectSettings valueForRelPath:relPath andKey:@"format_android"] intValue];
+            self.dither = [[_projectSettings valueForRelPath:relPath andKey:@"format_android_dither"] boolValue];
+            self.compress = [[_projectSettings valueForRelPath:relPath andKey:@"format_android_compress"] boolValue];
+        }
     }
 }
 

--- a/SpriteBuilder/ccBuilder/PublishRenamedFilesLookup.h
+++ b/SpriteBuilder/ccBuilder/PublishRenamedFilesLookup.h
@@ -1,12 +1,35 @@
 #import <Foundation/Foundation.h>
 
+// TODO: Move to it's own file after cherry picking
+@protocol PublishFileLookupProtocol <NSObject>
 
-@interface PublishRenamedFilesLookup : NSObject
+- (void)addRenamingRuleFrom:(NSString *)src to:(NSString *)dst;
+
+@end
+
+
+#pragma mark -----------------------------------------------------------------------------
+
+// TODO: Move to it's own file after cherry picking
+@interface PublishIntermediateFilesLookup : NSObject <PublishFileLookupProtocol>
+
+- (instancetype)initWithFlattenPaths:(BOOL)flattenPaths;
+
+- (BOOL)writeToFile:(NSString *)path;
+
+@end
+
+
+#pragma mark -----------------------------------------------------------------------------
+
+@interface PublishRenamedFilesLookup : NSObject  <PublishFileLookupProtocol>
 
 - (id)initWithFlattenPaths:(BOOL)flattenPaths;
 
 - (void)addRenamingRuleFrom:(NSString *)src to:(NSString *)dst;
 
 - (BOOL)writeToFileAtomically:(NSString *)filePath;
+
+- (void)addIntermediateLookupPath:(NSString *)filePath;
 
 @end

--- a/SpriteBuilder/ccBuilder/PublishRenamedFilesLookup.m
+++ b/SpriteBuilder/ccBuilder/PublishRenamedFilesLookup.m
@@ -1,10 +1,58 @@
 #import "PublishRenamedFilesLookup.h"
 
+@interface PublishIntermediateFilesLookup()
+
+@property (nonatomic, strong) NSMutableDictionary *lookup;
+@property (nonatomic) BOOL flattenPaths;
+
+@end
+
+@implementation PublishIntermediateFilesLookup
+
+- (instancetype)initWithFlattenPaths:(BOOL)flattenPaths
+{
+    self = [super init];
+    if (self)
+    {
+        self.flattenPaths = flattenPaths;
+        self.lookup = [NSMutableDictionary dictionary];
+    }
+
+    return self;
+}
+
+- (void)addRenamingRuleFrom:(NSString *)src to:(NSString *)dst
+{
+    if (_flattenPaths)
+    {
+        src = [src lastPathComponent];
+        dst = [dst lastPathComponent];
+    }
+
+    if ([src isEqualToString:dst])
+    {
+        return;
+    }
+
+    [_lookup setObject:dst forKey:src];
+}
+
+- (BOOL)writeToFile:(NSString *)path
+{
+    return [_lookup writeToFile:path atomically:YES];
+}
+
+@end
+
+
+
+#pragma mark -----------------------------------------------------------------------------
 
 @interface PublishRenamedFilesLookup ()
 
 @property (nonatomic, strong) NSMutableDictionary *lookup;
 @property (nonatomic) BOOL flattenPaths;
+@property (nonatomic, strong) NSMutableSet *intermediateLookupPaths;
 
 @end
 
@@ -18,6 +66,7 @@
     {
         self.flattenPaths = flattenPaths; 
         self.lookup = [NSMutableDictionary dictionary];
+        self.intermediateLookupPaths = [NSMutableSet set];
     }
 
     return self;
@@ -41,6 +90,9 @@
 
 - (BOOL)writeToFileAtomically:(NSString *)filePath
 {
+    NSMutableDictionary *intermediateLookups = [self loadAndMergeIntermediateLookups];
+    [_lookup addEntriesFromDictionary:intermediateLookups];
+
     NSMutableDictionary *plist = [NSMutableDictionary dictionary];
 
     NSMutableDictionary *metadata = [NSMutableDictionary dictionary];
@@ -50,6 +102,30 @@
     [plist setObject:_lookup forKey:@"filenames"];
 
     return [plist writeToFile:filePath atomically:YES];
+}
+
+- (NSMutableDictionary *)loadAndMergeIntermediateLookups
+{
+    NSMutableDictionary *result = [NSMutableDictionary dictionary];
+    for (NSString *intermediateLookupPath in _intermediateLookupPaths)
+    {
+        NSDictionary *content = [NSDictionary dictionaryWithContentsOfFile:intermediateLookupPath];
+        if (content)
+        {
+            [result addEntriesFromDictionary:content];
+        }
+    }
+    return result;
+}
+
+- (void)addIntermediateLookupPath:(NSString *)filePath
+{
+    if (!filePath)
+    {
+        return;
+    }
+
+    [_intermediateLookupPaths addObject:filePath];
 }
 
 - (NSString *)description

--- a/SpriteBuilder/ccBuilder/PublishSpriteSheetOperation.m
+++ b/SpriteBuilder/ccBuilder/PublishSpriteSheetOperation.m
@@ -50,13 +50,13 @@ static NSMutableSet *__spriteSheetPreviewsGenerated;
 
 - (void)assertProperties
 {
-    NSAssert(_spriteSheetFile != nil, @"spriteSheetFile should not be nil");
-    NSAssert(_subPath != nil, @"subPath should not be nil");
-    NSAssert(_srcDirs != nil, @"srcDirs should not be nil");
-    NSAssert(_resolution != nil, @"resolution should not be nil");
-    NSAssert(_srcSpriteSheetDate != nil, @"srcSpriteSheetDate should not be nil");
-    NSAssert(_publishDirectory != nil, @"publishDirectory should not be nil");
-    NSAssert(_publishedPNGFiles != nil, @"publishedPNGFiles should not be nil");
+    NSAssert(_spriteSheetFile != nil, @"spriteSheetFile must not be nil");
+    NSAssert(_subPath != nil, @"subPath must not be nil");
+    NSAssert(_srcDirs != nil, @"srcDirs must not be nil");
+    NSAssert(_resolution != nil, @"resolution must not be nil");
+    NSAssert(_srcSpriteSheetDate != nil, @"srcSpriteSheetDate must not be nil");
+    NSAssert(_publishDirectory != nil, @"publishDirectory must not be nil");
+    NSAssert(_publishedPNGFiles != nil, @"publishedPNGFiles must not be nil");
 }
 
 - (void)publishSpriteSheet


### PR DESCRIPTION
Bugfix for **Issue #649 with psds and smart sprite sheets.**
### Please add to 1.1 branch(Kept it in one commit to keep cherrypicking simpler)

Republishing for a unchanged already published smart spritesheet caused the fllelookup to be overwritten without the renaming rules.
Solution: Sprite sheet operation create an intermediate filelookup file in the smartsheet folder which is then loaded and merged with all other lookups and intermediate lookups.
Intermediate filelookups are deleted if smartsheet flag is removed from folder.
