### PR TITLE
Bugfix: Github issue #649.

### DIFF
--- a/SpriteBuilder/ccBuilder/NSString+Publishing.h
+++ b/SpriteBuilder/ccBuilder/NSString+Publishing.h
@@ -33,4 +33,5 @@
 // Recursively tests if the path contains a file with a .ccb suffix
 - (BOOL)containsCCBFile;
 
+- (BOOL)isIntermediateFileLookup;
 @end

--- a/SpriteBuilder/ccBuilder/NSString+Publishing.m
+++ b/SpriteBuilder/ccBuilder/NSString+Publishing.m
@@ -164,5 +164,9 @@
     return NO;
 }
 
+- (BOOL)isIntermediateFileLookup
+{
+    return [self isEqualToString:@"intermediateFileLookup.plist"];
+}
 
 @end

--- a/SpriteBuilder/ccBuilder/ProjectSettings.m
+++ b/SpriteBuilder/ccBuilder/ProjectSettings.m
@@ -364,10 +364,26 @@
     NSAssert(res.type == kCCBResTypeDirectory, @"Resource must be directory");
     
     [self removeObjectForResource:res andKey:@"isSmartSpriteSheet"];
-    
+
+    [self removeIntermediateFileLookupFile:res];
+
     [self store];
     [[ResourceManager sharedManager] notifyResourceObserversResourceListUpdated];
     [[AppDelegate appDelegate].projectOutlineHandler updateSelectionPreview];
+}
+
+- (void)removeIntermediateFileLookupFile:(RMResource *)res
+{
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSString *intermediateFileLookup = [res.filePath stringByAppendingPathComponent:@"intermediateFileLookup.plist"];
+    if ([fileManager fileExistsAtPath:intermediateFileLookup])
+    {
+        NSError *error;
+        if (![fileManager removeItemAtPath:intermediateFileLookup error:&error])
+        {
+            NSLog(@"Error removing intermediate filelookup file %@ - %@", intermediateFileLookup, error);
+        }
+    }
 }
 
 - (void) setValue:(id) val forResource:(RMResource*) res andKey:(id) key

--- a/SpriteBuilder/ccBuilder/PublishGeneratedFilesOperation.m
+++ b/SpriteBuilder/ccBuilder/PublishGeneratedFilesOperation.m
@@ -96,7 +96,10 @@
 
 - (void)generateFileLookup
 {
-    [_fileLookup writeToFileAtomically:[_outputDir stringByAppendingPathComponent:@"fileLookup.plist"]];
+    if (![_fileLookup writeToFileAtomically:[_outputDir stringByAppendingPathComponent:@"fileLookup.plist"]])
+    {
+        [_warnings addWarningWithDescription:@"Could not write fileLookup.plist."];
+    }
 }
 
 - (NSString *)description

--- a/SpriteBuilder/ccBuilder/PublishImageOperation.h
+++ b/SpriteBuilder/ccBuilder/PublishImageOperation.h
@@ -6,6 +6,7 @@
 @class CCBPublisher;
 @class FCFormatConverter;
 @class PublishRenamedFilesLookup;
+@protocol PublishFileLookupProtocol;
 
 @interface PublishImageOperation : PublishBaseOperation
 
@@ -15,7 +16,7 @@
 @property (nonatomic, copy) NSString *resolution;
 
 @property (nonatomic, strong) NSMutableSet *publishedPNGFiles;
-@property (nonatomic, strong) PublishRenamedFilesLookup *fileLookup;
+@property (nonatomic, strong) id<PublishFileLookupProtocol> fileLookup;
 
 @property (nonatomic) BOOL isSpriteSheet;
 @property (nonatomic) CCBPublisherTargetType targetType;

--- a/SpriteBuilder/ccBuilder/PublishRenamedFilesLookup.h
+++ b/SpriteBuilder/ccBuilder/PublishRenamedFilesLookup.h
@@ -1,12 +1,35 @@
 #import <Foundation/Foundation.h>
 
+// TODO: Move to it's own file after cherry picking
+@protocol PublishFileLookupProtocol <NSObject>
 
-@interface PublishRenamedFilesLookup : NSObject
+- (void)addRenamingRuleFrom:(NSString *)src to:(NSString *)dst;
+
+@end
+
+
+#pragma mark -----------------------------------------------------------------------------
+
+// TODO: Move to it's own file after cherry picking
+@interface PublishIntermediateFilesLookup : NSObject <PublishFileLookupProtocol>
+
+- (instancetype)initWithFlattenPaths:(BOOL)flattenPaths;
+
+- (BOOL)writeToFile:(NSString *)path;
+
+@end
+
+
+#pragma mark -----------------------------------------------------------------------------
+
+@interface PublishRenamedFilesLookup : NSObject  <PublishFileLookupProtocol>
 
 - (id)initWithFlattenPaths:(BOOL)flattenPaths;
 
 - (void)addRenamingRuleFrom:(NSString *)src to:(NSString *)dst;
 
 - (BOOL)writeToFileAtomically:(NSString *)filePath;
+
+- (void)addIntermediateLookupPath:(NSString *)filePath;
 
 @end

--- a/SpriteBuilder/ccBuilder/PublishRenamedFilesLookup.m
+++ b/SpriteBuilder/ccBuilder/PublishRenamedFilesLookup.m
@@ -1,10 +1,58 @@
 #import "PublishRenamedFilesLookup.h"
 
+@interface PublishIntermediateFilesLookup()
+
+@property (nonatomic, strong) NSMutableDictionary *lookup;
+@property (nonatomic) BOOL flattenPaths;
+
+@end
+
+@implementation PublishIntermediateFilesLookup
+
+- (instancetype)initWithFlattenPaths:(BOOL)flattenPaths
+{
+    self = [super init];
+    if (self)
+    {
+        self.flattenPaths = flattenPaths;
+        self.lookup = [NSMutableDictionary dictionary];
+    }
+
+    return self;
+}
+
+- (void)addRenamingRuleFrom:(NSString *)src to:(NSString *)dst
+{
+    if (_flattenPaths)
+    {
+        src = [src lastPathComponent];
+        dst = [dst lastPathComponent];
+    }
+
+    if ([src isEqualToString:dst])
+    {
+        return;
+    }
+
+    [_lookup setObject:dst forKey:src];
+}
+
+- (BOOL)writeToFile:(NSString *)path
+{
+    return [_lookup writeToFile:path atomically:YES];
+}
+
+@end
+
+
+
+#pragma mark -----------------------------------------------------------------------------
 
 @interface PublishRenamedFilesLookup ()
 
 @property (nonatomic, strong) NSMutableDictionary *lookup;
 @property (nonatomic) BOOL flattenPaths;
+@property (nonatomic, strong) NSMutableSet *intermediateLookupPaths;
 
 @end
 
@@ -18,6 +66,7 @@
     {
         self.flattenPaths = flattenPaths; 
         self.lookup = [NSMutableDictionary dictionary];
+        self.intermediateLookupPaths = [NSMutableSet set];
     }
 
     return self;
@@ -41,6 +90,9 @@
 
 - (BOOL)writeToFileAtomically:(NSString *)filePath
 {
+    NSMutableDictionary *intermediateLookups = [self loadAndMergeIntermediateLookups];
+    [_lookup addEntriesFromDictionary:intermediateLookups];
+
     NSMutableDictionary *plist = [NSMutableDictionary dictionary];
 
     NSMutableDictionary *metadata = [NSMutableDictionary dictionary];
@@ -50,6 +102,30 @@
     [plist setObject:_lookup forKey:@"filenames"];
 
     return [plist writeToFile:filePath atomically:YES];
+}
+
+- (NSMutableDictionary *)loadAndMergeIntermediateLookups
+{
+    NSMutableDictionary *result = [NSMutableDictionary dictionary];
+    for (NSString *intermediateLookupPath in _intermediateLookupPaths)
+    {
+        NSDictionary *content = [NSDictionary dictionaryWithContentsOfFile:intermediateLookupPath];
+        if (content)
+        {
+            [result addEntriesFromDictionary:content];
+        }
+    }
+    return result;
+}
+
+- (void)addIntermediateLookupPath:(NSString *)filePath
+{
+    if (!filePath)
+    {
+        return;
+    }
+
+    [_intermediateLookupPaths addObject:filePath];
 }
 
 - (NSString *)description


### PR DESCRIPTION
Bugfix for **Issue #649 with psds and smart sprite sheets.**

**This can be merged into develop as well as 1.1.**

Republishing for a unchanged already published smart spritesheet caused the fllelookup to be overwritten without the renaming rules.
Solution: Sprite sheet operation create an intermediate filelookup file in the smartsheet folder which is then loaded and merged with all other lookups and intermediate lookups.
Intermediate filelookups are deleted if smartsheet flag is removed from folder.

Issue with psds and smart sprite sheets.
Republishing for a unchanged already published smart spritesheet caused the fllelookup to be overwritten without the renaming rules.
Solution: Sprite sheet operation create an intermediate filelookup file in the smartsheet folder which is then loaded and merged with all other lookups and intermediate lookups.
Intermediate filelookups are deleted if smartsheet flag is removed from folder.
