### PR TITLE
Bugfix/1.1/#664 release publish optipng

### DIFF
--- a/SpriteBuilder/ccBuilder/CCBPublisher.m
+++ b/SpriteBuilder/ccBuilder/CCBPublisher.m
@@ -99,7 +99,7 @@
 {
     for (NSString* resolution in _publishForResolutions)
     {
-        [self publishImageFile:srcFile to:dstFile isSpriteSheet:isSpriteSheet outputDir:outDir resolution:resolution];
+        [self publishImageFile:srcFile to:dstFile isSpriteSheet:isSpriteSheet outputDir:outDir resolution:resolution intermediateProduct:NO];
 	}
 
     return YES;
@@ -110,6 +110,7 @@
            isSpriteSheet:(BOOL)isSpriteSheet
                outputDir:(NSString *)outputDir
               resolution:(NSString *)resolution
+     intermediateProduct:(BOOL)intermediateProduct
 {
     PublishImageOperation *operation = [[PublishImageOperation alloc] initWithProjectSettings:_projectSettings
                                                                                      warnings:_warnings
@@ -122,8 +123,9 @@
     operation.resolution = resolution;
     operation.targetType = _targetType;
     operation.modifiedFileDateCache = _modifiedDatesCache;
-    operation.publishedPNGFiles = _publishedPNGFiles;
     operation.fileLookup = _renamedFilesLookup;
+    operation.publishedPNGFiles = _publishedPNGFiles;
+    operation.intermediateProduct = intermediateProduct;
 
     [_publishingQueue addOperation:operation];
     return YES;
@@ -486,7 +488,8 @@
                                 to:dstFile
                      isSpriteSheet:NO
                          outputDir:outputDir
-                        resolution:resolution];
+                        resolution:resolution
+               intermediateProduct:YES];
         }
     }
 }

--- a/SpriteBuilder/ccBuilder/PublishImageOperation.h
+++ b/SpriteBuilder/ccBuilder/PublishImageOperation.h
@@ -22,4 +22,6 @@
 
 @property (nonatomic, strong) DateCache *modifiedFileDateCache;
 
+@property (nonatomic) BOOL intermediateProduct;
+
 @end

--- a/SpriteBuilder/ccBuilder/PublishImageOperation.m
+++ b/SpriteBuilder/ccBuilder/PublishImageOperation.m
@@ -163,6 +163,7 @@
         [CCBFileUtil setModificationDate:srcDate forFile:dstPathConverted];
 
         if (!_isSpriteSheet
+            && !_intermediateProduct
             && format == kFCImageFormatPNG)
         {
             [_publishedPNGFiles addObject:dstPathConverted];
@@ -209,6 +210,7 @@
         [CCBFileUtil setModificationDate:srcDate forFile:dstPathConverted];
 
         if (!_isSpriteSheet
+            && !_intermediateProduct
             && format == kFCImageFormatPNG)
         {
             [_publishedPNGFiles addObject:dstPathConverted];


### PR DESCRIPTION
pull request for develop.

optipng was applied to intermediate product for smart spritesheet creation which lead to file not found errors. harmless but not helpful for users.

fixes: https://github.com/spritebuilder/SpriteBuilder/issues/664

forum: http://forum.spritebuilder.com/t/errors-publishing-as-release-issue-raised/1296
