### PR TITLE
Bugfix for github issue #672 @ 1.1

### DIFF
--- a/SpriteBuilder/ccBuilder/CCBPublisher.m
+++ b/SpriteBuilder/ccBuilder/CCBPublisher.m
@@ -468,6 +468,7 @@
             {
                 [_warnings addWarningWithDescription:[NSString stringWithFormat:@"Could not write intermediate file lookup for smart spritesheet %@ @ %@", spriteSheetName, resolution]];
             }
+            [CCBFileUtil setModificationDate:srcSpriteSheetDate forFile:intermediateFileLookupPath];
         }];
 	}
 }

--- a/SpriteBuilder/ccBuilder/CCBPublisher.m
+++ b/SpriteBuilder/ccBuilder/CCBPublisher.m
@@ -428,7 +428,7 @@
         [fileManager removeItemAtPath:[_projectSettings tempSpriteSheetCacheDirectory] error:NULL];
     }];
 
-    NSDate *srcSpriteSheetDate = [publishDirectory latestModifiedDateOfPath];
+    NSDate *srcSpriteSheetDate = [publishDirectory latestModifiedDateOfPathIgnoringDirs:YES];
 
 	[_publishedSpriteSheetFiles addObject:[subPath stringByAppendingPathExtension:@"plist"]];
 

--- a/SpriteBuilder/ccBuilder/NSString+Publishing.h
+++ b/SpriteBuilder/ccBuilder/NSString+Publishing.h
@@ -25,7 +25,7 @@
 - (NSArray *)resolutionDependantFilesInDirWithResolutions:(NSArray *)resolutions;
 
 // Traverses recursively the directory and returns the latest date of all files found. Quite expensive operation.
-- (NSDate *)latestModifiedDateOfPath;
+- (NSDate *)latestModifiedDateOfPathIgnoringDirs:(BOOL)ignoreDirs;
 
 // Shallow search for all files with the .png suffix and returns them
 - (NSArray *)allPNGFilesInPath;

--- a/SpriteBuilder/ccBuilder/NSString+Publishing.m
+++ b/SpriteBuilder/ccBuilder/NSString+Publishing.m
@@ -33,14 +33,16 @@
     return [extension isEqualToString:@"png"] || [extension isEqualToString:@"psd"];
 }
 
-- (NSDate *)latestModifiedDateOfPath
+- (NSDate *)latestModifiedDateOfPathIgnoringDirs:(BOOL)ignoreDirs
 {
-    return [self latestModifiedDateForDirectory:self];
+    return [self latestModifiedDateForDirectory:self ignoreDirs:ignoreDirs];
 }
 
-- (NSDate *)latestModifiedDateForDirectory:(NSString *)dir
+- (NSDate *)latestModifiedDateForDirectory:(NSString *)dir ignoreDirs:(BOOL)ignoreDirs
 {
-	NSDate* latestDate = [CCBFileUtil modificationDateForFile:dir];
+	NSDate* latestDate = ignoreDirs
+        ? [NSDate distantPast]
+        : [CCBFileUtil modificationDateForFile:dir];
 
     NSArray* files = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:dir error:NULL];
     for (NSString* file in files)
@@ -54,7 +56,7 @@
 
             if (isDir)
             {
-				fileDate = [self latestModifiedDateForDirectory:absFile];
+				fileDate = [self latestModifiedDateForDirectory:absFile ignoreDirs:ignoreDirs];
 			}
             else
             {

--- a/SpriteBuilder/ccBuilder/PublishSpriteSheetOperation.m
+++ b/SpriteBuilder/ccBuilder/PublishSpriteSheetOperation.m
@@ -61,7 +61,7 @@ static NSMutableSet *__spriteSheetPreviewsGenerated;
 
 - (void)publishSpriteSheet
 {
-    [_publishingTaskStatusProgress updateStatusText:[NSString stringWithFormat:@"Generating sprite sheet %@...", [[_subPath stringByAppendingPathExtension:@"plist"] lastPathComponent]]];
+    [_publishingTaskStatusProgress updateStatusText:[NSString stringWithFormat:@"Generating sprite sheet %@...", [_subPath lastPathComponent]]];
 
     [self loadSettings];
 
@@ -73,7 +73,15 @@ static NSMutableSet *__spriteSheetPreviewsGenerated;
 
     [self processWarnings];
 
-    [CCBFileUtil setModificationDate:_srcSpriteSheetDate forFile:[_spriteSheetFile stringByAppendingPathExtension:@"plist"]];
+    [self setDateForCreatedFiles:createdFiles];
+}
+
+- (void)setDateForCreatedFiles:(NSArray *)createFiles
+{
+    for (NSString *filePath in createFiles)
+    {
+        [CCBFileUtil setModificationDate:_srcSpriteSheetDate forFile:filePath];
+    }
 }
 
 - (void)addCreatedPNGFilesToCreatedFilesSet:(NSArray *)createdFiles


### PR DESCRIPTION
Spritesheets publishing was not skipped even if no changes were made.
File modifcation date used to test for changes got out of sync after introduction of intermediatefilelookup.plist files.
Changed publishing status update message for spritesheets, now without plist extension for current filename.
