### PR TITLE
Enable undo / redo and immediate saving of changes to collisionType property of a physics enabled node

### DIFF
--- a/SpriteBuilder/ccBuilder/NodePhysicsBody.h
+++ b/SpriteBuilder/ccBuilder/NodePhysicsBody.h
@@ -48,7 +48,7 @@ typedef enum
 @property (nonatomic,assign) float friction;
 @property (nonatomic,assign) float elasticity;
 
-@property (nonatomic) NSString * collisionType;
+@property (nonatomic,copy) NSString * collisionType;
 @property (nonatomic) NSArray * collisionCategories;
 @property (nonatomic) NSArray * collisionMask;
 

--- a/SpriteBuilder/ccBuilder/NodePhysicsBody.m
+++ b/SpriteBuilder/ccBuilder/NodePhysicsBody.m
@@ -332,6 +332,15 @@
     _elasticity = elasticity;
 }
 
+- (void) setCollisionType:(NSString *)collisionType
+{
+    if (![_collisionType isEqualToString:collisionType])
+    {
+        [[AppDelegate appDelegate] saveUndoStateWillChangeProperty:@"*P*collisionType"];
+        _collisionType = [collisionType copy];
+    }
+}
+
 - (void) dealloc
 {
 


### PR DESCRIPTION
There is a bug where changes to collision type don't get saved to the .ccb or published to the .ccbi unless some other property (e.g. density, friction, etc.) is changed.  This fixes that and also enables undo / redo on collision type.
