### PR TITLE
Add Internet permission in AndroidManifest.xml template

### DIFF
--- a/Support/PROJECTNAME.spritebuilder/Source/Resources/AndroidManifest.xml
+++ b/Support/PROJECTNAME.spritebuilder/Source/Resources/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="org.cocos2d.PROJECTIDENTIFIER" >
     <uses-feature android:glEsVersion="0x00020000" android:required="true" />
     <uses-sdk android:targetSdkVersion="14" android:minSdkVersion="9"></uses-sdk>
+    <uses-permission android:name="android.permission.INTERNET"></uses-permission>
     <application
         android:allowBackup="true"
         android:label="PROJECTNAME"


### PR DESCRIPTION
Allows Android debugging for all apps (including those that don't support the run-as command).
