### PR TITLE
Bugfix for issue #940: "Slightly trimmed name of the image is displayed ...

### DIFF
--- a/SpriteBuilder/ccBuilder/ImageAndTextCell.m
+++ b/SpriteBuilder/ccBuilder/ImageAndTextCell.m
@@ -167,6 +167,10 @@ static CGFloat IMAGE_PADDING_RIGHT = 3.0;
     NSMutableDictionary *attributes = [NSMutableDictionary dictionary];
     attributes[NSFontAttributeName] = self.font;
 
+    NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
+    [paragraphStyle setLineBreakMode:[self lineBreakMode]];
+    attributes[NSParagraphStyleAttributeName] = paragraphStyle;
+
     if ([self isHighlighted])
     {
         attributes[NSForegroundColorAttributeName] = [NSColor whiteColor];

--- a/SpriteBuilder/ccBuilder/ResourceManagerOutlineHandler.m
+++ b/SpriteBuilder/ccBuilder/ResourceManagerOutlineHandler.m
@@ -66,6 +66,8 @@
 
         ImageAndTextCell* imageTextCell = [[ImageAndTextCell alloc] init];
         [imageTextCell setEditable:YES];
+        [imageTextCell setLineBreakMode:NSLineBreakByTruncatingTail];
+
         [[resourceList outlineTableColumn] setDataCell:imageTextCell];
         [[resourceList outlineTableColumn] setEditable:YES];
 


### PR DESCRIPTION
...in the Resource/Component Browser when user drags any image that has long name."

ImageAndTextCell now applies lineBreakMode of cell to attributed string.
LineBreakMode set in ResourceManagerOutlineHandler.

Fixes https://github.com/spritebuilder/SpriteBuilder/issues/940.
