### PR TITLE
Bugfix for #973, feature added as in #865.

### DIFF
--- a/SpriteBuilder/SpriteBuilder Tests/FileSystemTestCase.m
+++ b/SpriteBuilder/SpriteBuilder Tests/FileSystemTestCase.m
@@ -78,7 +78,7 @@ NSString *const TEST_PATH = @"com.spritebuilder.tests";
 {
     for (NSString *relFolderPath in folders)
     {
-        NSString *fullPathForFolder = [_testDirecotoryPath stringByAppendingPathComponent:relFolderPath];
+        NSString *fullPathForFolder = [self fullPathForFile:relFolderPath];
         NSError *error;
         XCTAssertTrue([_fileManager createDirectoryAtPath:fullPathForFolder withIntermediateDirectories:YES attributes:nil error:&error],
                       @"Could not create folder \"%@\", error: %@", fullPathForFolder, error);
@@ -92,7 +92,7 @@ NSString *const TEST_PATH = @"com.spritebuilder.tests";
     {
         NSData *emptyStringData = [@"" dataUsingEncoding:NSUTF8StringEncoding];
 
-        [dictionary setObject:emptyStringData forKey:relFilePath];
+        dictionary[relFilePath] = emptyStringData;
     }
 
     [self createFilesWithContents:dictionary];

--- a/SpriteBuilder/SpriteBuilder Tests/PackagePublishSettings_Tests.m
+++ b/SpriteBuilder/SpriteBuilder Tests/PackagePublishSettings_Tests.m
@@ -109,7 +109,14 @@
     _packagePublishSettings.publishToCustomOutputDirectory = NO;
 
     SBAssertStringsEqual(_packagePublishSettings.effectiveOutputDirectory, DEFAULT_OUTPUTDIR_PUBLISHED_PACKAGES);
-}
 
+    _packagePublishSettings.customOutputDirectory = nil;
+    _packagePublishSettings.publishToCustomOutputDirectory = YES;
+    SBAssertStringsEqual(_packagePublishSettings.effectiveOutputDirectory, DEFAULT_OUTPUTDIR_PUBLISHED_PACKAGES);
+
+    _packagePublishSettings.customOutputDirectory = @"    ";
+    _packagePublishSettings.publishToCustomOutputDirectory = YES;
+    SBAssertStringsEqual(_packagePublishSettings.effectiveOutputDirectory, DEFAULT_OUTPUTDIR_PUBLISHED_PACKAGES);
+}
 
 @end

--- a/SpriteBuilder/SpriteBuilder Tests/PublishUtil_Tests.m
+++ b/SpriteBuilder/SpriteBuilder Tests/PublishUtil_Tests.m
@@ -1,0 +1,88 @@
+//
+//  PublishUtil_Tests.m
+//  SpriteBuilder
+//
+//  Created by Nicky Weber on 16.10.14.
+//
+//
+
+#import <Cocoa/Cocoa.h>
+#import <XCTest/XCTest.h>
+#import "FileSystemTestCase.h"
+#import "ProjectSettings.h"
+#import "PublishUtil.h"
+
+@interface PublishUtil_Tests : FileSystemTestCase
+
+@property (nonatomic, strong) ProjectSettings *projectSettings;
+
+@end
+
+
+@implementation PublishUtil_Tests
+
+- (void)setUp
+{
+    [super setUp];
+
+    NSString *relPathToProjectFile = @"baa/projects/foo.spritebuilder/foo.ccbproj";
+    [self createEmptyFiles:@[relPathToProjectFile]];
+
+    self.projectSettings = [[ProjectSettings alloc] init];
+    _projectSettings.projectPath = [self fullPathForFile:relPathToProjectFile];
+}
+
+- (void)testDirectoryContrainingProjectDir
+{
+    // ../.. translates to /TESTFOLDER/baa/projects
+    PublishDirectoryDeletionRisk result = [PublishUtil riskForPublishDirectoryBeingDeletedUponPublish:@".."
+                                                                                      projectSettings:_projectSettings];
+    XCTAssertEqual(PublishDirectoryDeletionRiskDirectoryContainingProject, result);
+}
+
+- (void)testProjectfolderItselfAtRisk
+{
+    // ../.. translates to /TESTFOLDER/baa/projects/foo.spritebuilder
+    PublishDirectoryDeletionRisk result = [PublishUtil riskForPublishDirectoryBeingDeletedUponPublish:@"."
+                                                                                      projectSettings:_projectSettings];
+    XCTAssertEqual(PublishDirectoryDeletionRiskDirectoryContainingProject, result);
+}
+
+- (void)testNonEmptyDirectory
+{
+    // Test non empty folder inside of project dir
+    NSString *relPathNonEmptyFolder = [_projectSettings.projectPathDir stringByAppendingPathComponent:@"nonempty"];
+    [self createEmptyFiles:@[[relPathNonEmptyFolder stringByAppendingPathComponent:@"foo.text"]]];
+
+    PublishDirectoryDeletionRisk result = [PublishUtil riskForPublishDirectoryBeingDeletedUponPublish:relPathNonEmptyFolder
+                                                                                      projectSettings:_projectSettings];
+    XCTAssertEqual(PublishDirectoryDeletionRiskNonEmptyDirectory, result);
+
+
+    // Test non empty folder outside of project dir
+    [self createEmptyFiles:@[[[self fullPathForFile:@"temp"] stringByAppendingPathComponent:@"foo.text"]]];
+    // ../../temp translates to /TESTFOLDER/temp
+    PublishDirectoryDeletionRisk result2 = [PublishUtil riskForPublishDirectoryBeingDeletedUponPublish:@"../../../temp"
+                                                                                       projectSettings:_projectSettings];
+    XCTAssertEqual(PublishDirectoryDeletionRiskNonEmptyDirectory, result2);
+}
+
+- (void)testEmptyFolder
+{
+    // Test empty folder inside of project dir
+    NSString *relPathEmptyFolder = [_projectSettings.projectPathDir stringByAppendingPathComponent:@"empty"];
+    [self createFolders:@[relPathEmptyFolder]];
+
+    PublishDirectoryDeletionRisk result = [PublishUtil riskForPublishDirectoryBeingDeletedUponPublish:relPathEmptyFolder
+                                                                                      projectSettings:_projectSettings];
+
+    XCTAssertEqual(PublishDirectoryDeletionRiskSafe, result);
+
+    // Test empty folder outside of project dir
+    [self createFolders:@[@"temp"]];
+    PublishDirectoryDeletionRisk result2 = [PublishUtil riskForPublishDirectoryBeingDeletedUponPublish:@"../../../temp"
+                                                                                       projectSettings:_projectSettings];
+    XCTAssertEqual(PublishDirectoryDeletionRiskSafe, result2);
+}
+
+@end

--- a/SpriteBuilder/SpriteBuilder.xcodeproj/project.pbxproj
+++ b/SpriteBuilder/SpriteBuilder.xcodeproj/project.pbxproj
@@ -814,6 +814,7 @@
 		E525F0CA1647993A7388B7BC /* InspectorStringSimple.m in Sources */ = {isa = PBXBuildFile; fileRef = E525FA43EE7D1C6B7C52E601 /* InspectorStringSimple.m */; };
 		E525F0EA925087B3D2ABE8D3 /* ResourceNewPackageCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = E525FDFD10EE6761E4E94BED /* ResourceNewPackageCommand.m */; };
 		E525F12B1E4605EB494FA44C /* PackageMigrationController.m in Sources */ = {isa = PBXBuildFile; fileRef = E525F7254C3A84AA7585A1F8 /* PackageMigrationController.m */; };
+		E525F165B4E19784684E39D4 /* PublishUtil_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E525FA2C90028FB3D047213C /* PublishUtil_Tests.m */; };
 		E525F1775124A78C8A2FFE99 /* InspectorSize.m in Sources */ = {isa = PBXBuildFile; fileRef = E525F4BF41919531FA401AC5 /* InspectorSize.m */; };
 		E525F19F8822F8E8D632F4FE /* InspectorCodeConnectionsJS.m in Sources */ = {isa = PBXBuildFile; fileRef = E525FD5B0F64DC8D7BC147CF /* InspectorCodeConnectionsJS.m */; };
 		E525F1D290DC4186045DF385 /* InspectorBlendmode.m in Sources */ = {isa = PBXBuildFile; fileRef = E525F80A01670D35DE164CE4 /* InspectorBlendmode.m */; };
@@ -832,6 +833,7 @@
 		E525F2C0B3311DCAEC86C6B0 /* PublishImageOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = E525FC7FEB1B9D2A5F7FFEA5 /* PublishImageOperation.m */; };
 		E525F2CA0ED42F21A4777F2E /* InspectorPopoverFloat.xib in Resources */ = {isa = PBXBuildFile; fileRef = E525FF4F0648F14C369A8E7B /* InspectorPopoverFloat.xib */; };
 		E525F2D49FBDA5CF8C8F0026 /* InspectorFlip.m in Sources */ = {isa = PBXBuildFile; fileRef = E525FE849808293F2D7051BA /* InspectorFlip.m */; };
+		E525F30359F75816D1F178F1 /* PublishUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = E525FE25558D5B40E8284D62 /* PublishUtil.m */; };
 		E525F3051C62E3CBA69E877A /* InspectorIntegerLabeled.xib in Resources */ = {isa = PBXBuildFile; fileRef = E525F90E4BCE3BA5130B8E9D /* InspectorIntegerLabeled.xib */; };
 		E525F308447A45DFEE6C23EE /* ProjectMigrator.m in Sources */ = {isa = PBXBuildFile; fileRef = E525F9C63E463EE451384EBB /* ProjectMigrator.m */; };
 		E525F30A9EE36DBB3B363EE8 /* PackagePublishSettings_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E525FC9B1AB11FC59D613AA1 /* PackagePublishSettings_Tests.m */; };
@@ -2431,6 +2433,7 @@
 		E3FD4DDE15A455B90032C2DD /* SequencerSequenceArrayController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SequencerSequenceArrayController.m; sourceTree = "<group>"; };
 		E525F001371D1628D87FFF3E /* RMResourceBase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMResourceBase.m; sourceTree = "<group>"; };
 		E525F0021A81F90852D0875E /* InspectorFlip.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = InspectorFlip.xib; sourceTree = "<group>"; };
+		E525F002E61AB0221373A9E7 /* PublishUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PublishUtil.h; sourceTree = "<group>"; };
 		E525F01EE8CDFEE970D1C645 /* InspectorFloatCheck.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = InspectorFloatCheck.xib; sourceTree = "<group>"; };
 		E525F0219F49F375C2F5DED2 /* PackageMigrator_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PackageMigrator_Tests.m; sourceTree = "<group>"; };
 		E525F0424E2063AF911B0692 /* ResourceExportPackageCommand.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ResourceExportPackageCommand.m; sourceTree = "<group>"; };
@@ -2642,6 +2645,7 @@
 		E525FA122097E3A343BA0A68 /* RMResource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMResource.h; sourceTree = "<group>"; };
 		E525FA15437B8CAB27509534 /* NSString+Packages.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+Packages.m"; sourceTree = "<group>"; };
 		E525FA2687DAA762E0CF0430 /* ResourceCreateKeyframesCommand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ResourceCreateKeyframesCommand.h; sourceTree = "<group>"; };
+		E525FA2C90028FB3D047213C /* PublishUtil_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PublishUtil_Tests.m; sourceTree = "<group>"; };
 		E525FA39177A6B3C303B9DA6 /* InspectorFontTTF.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InspectorFontTTF.m; sourceTree = "<group>"; };
 		E525FA41F314DDA60057099D /* InspectorColor3.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InspectorColor3.m; sourceTree = "<group>"; };
 		E525FA43EE7D1C6B7C52E601 /* InspectorStringSimple.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InspectorStringSimple.m; sourceTree = "<group>"; };
@@ -2727,6 +2731,7 @@
 		E525FE05E5E4D72C7A63437A /* PackageRemover_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PackageRemover_Tests.m; sourceTree = "<group>"; };
 		E525FE0A3AA113A1EB758EAC /* PackageCreator_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PackageCreator_Tests.m; sourceTree = "<group>"; };
 		E525FE21A2662188C1454FEB /* InspectorNodeReference.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InspectorNodeReference.h; sourceTree = "<group>"; };
+		E525FE25558D5B40E8284D62 /* PublishUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PublishUtil.m; sourceTree = "<group>"; };
 		E525FE331D09AEA8E9CB4145 /* PackageUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PackageUtil.h; sourceTree = "<group>"; };
 		E525FE520C891B3D37F5F564 /* InspectorStartStop.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InspectorStartStop.h; sourceTree = "<group>"; };
 		E525FE561C3F2F72AC9FD31B /* InspectorCustom.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InspectorCustom.m; sourceTree = "<group>"; };
@@ -4969,6 +4974,8 @@
 				E525F7FF46AF3A6A44E16D69 /* CCBPublisherController.m */,
 				E525F3100A5F52133B82A32B /* CCBPublisherController.h */,
 				E525F8D24C0C5FA581D7E9B8 /* PublishingFinishedDelegate.h */,
+				E525FE25558D5B40E8284D62 /* PublishUtil.m */,
+				E525F002E61AB0221373A9E7 /* PublishUtil.h */,
 			);
 			name = Publishing;
 			sourceTree = "<group>";
@@ -5777,6 +5784,7 @@
 				E525F770E84E88D9786A9D65 /* PublishingOperations */,
 				E525FC042369604B80B893DB /* CCBPublisher_Tests.m */,
 				E525FA6F3FA1EC682616EB41 /* CCBPublisherController_Tests.m */,
+				E525FA2C90028FB3D047213C /* PublishUtil_Tests.m */,
 			);
 			name = Publishing;
 			sourceTree = "<group>";
@@ -7587,6 +7595,7 @@
 				E525F2B77CFD1B6D7D74A102 /* ResourcePropertyKeys.m in Sources */,
 				E525F45CD322A0BCB1A7EDBF /* ResourcePropertiesMigrator.m in Sources */,
 				E525FD8036350149E83701B4 /* ImageFormatAndPropertiesHelper.m in Sources */,
+				E525F30359F75816D1F178F1 /* PublishUtil.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7632,6 +7641,7 @@
 				E525F57D9C6C716295683654 /* PackageMigrator_Tests.m in Sources */,
 				E525F0BD99E8E797E5F4278F /* ResourcePropertiesMigrator_Tests.m in Sources */,
 				E525F7955AC7103E961D6553 /* PluginNode_Tests.m in Sources */,
+				E525F165B4E19784684E39D4 /* PublishUtil_Tests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SpriteBuilder/ccBuilder/PackagePublishSettings.m
+++ b/SpriteBuilder/ccBuilder/PackagePublishSettings.m
@@ -145,6 +145,7 @@ NSString *const KEY_PUBLISH_ENV = @"publishEnv";
 - (NSString *)effectiveOutputDirectory
 {
     return _publishToCustomOutputDirectory
+           && ([[_customOutputDirectory stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] length] > 0)
         ? _customOutputDirectory
         : DEFAULT_OUTPUTDIR_PUBLISHED_PACKAGES;
 }

--- a/SpriteBuilder/ccBuilder/ProjectSettingsWindowController.h
+++ b/SpriteBuilder/ccBuilder/ProjectSettingsWindowController.h
@@ -12,7 +12,7 @@
 @class ProjectSettings;
 @class PackagePublishSettings;
 
-@interface ProjectSettingsWindowController : CCBModalSheetController <NSTableViewDelegate>
+@interface ProjectSettingsWindowController : CCBModalSheetController <NSTableViewDelegate, NSOpenSavePanelDelegate>
 
 @property (nonatomic, weak) ProjectSettings* projectSettings;
 @property (nonatomic, strong) PackagePublishSettings *currentPackageSettings;

--- a/SpriteBuilder/ccBuilder/PublishUtil.h
+++ b/SpriteBuilder/ccBuilder/PublishUtil.h
@@ -1,0 +1,22 @@
+#import <Foundation/Foundation.h>
+
+@class ProjectSettings;
+
+
+typedef enum {
+    PublishDirectoryDeletionRiskSafe = 0,
+    PublishDirectoryDeletionRiskNonEmptyDirectory,
+    PublishDirectoryDeletionRiskDirectoryContainingProject
+} PublishDirectoryDeletionRisk;
+
+
+
+@interface PublishUtil : NSObject
+{
+
+}
+
++ (PublishDirectoryDeletionRisk)riskForPublishDirectoryBeingDeletedUponPublish:(NSString *)directory projectSettings:(ProjectSettings *)projectSettings;
+
+
+@end

--- a/SpriteBuilder/ccBuilder/PublishUtil.m
+++ b/SpriteBuilder/ccBuilder/PublishUtil.m
@@ -1,0 +1,43 @@
+#import "PublishUtil.h"
+#import "ProjectSettings.h"
+#import "NSString+RelativePath.h"
+
+
+@implementation PublishUtil
+
++ (PublishDirectoryDeletionRisk)riskForPublishDirectoryBeingDeletedUponPublish:(NSString *)directory projectSettings:(ProjectSettings *)projectSettings
+{
+    NSAssert(projectSettings != nil, @"projectSettings must not be nil");
+    NSAssert(directory  != nil, @"directory  must not be nil");
+
+    NSString *absolutePath = [directory absolutePathFromBaseDirPath:projectSettings.projectPathDir];
+
+    if ([projectSettings.projectPathDir rangeOfString:absolutePath].location != NSNotFound)
+    {
+        return PublishDirectoryDeletionRiskDirectoryContainingProject;
+    }
+
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    if ([fileManager fileExistsAtPath:absolutePath])
+    {
+        NSError *error;
+        NSArray *contents = [fileManager contentsOfDirectoryAtPath:absolutePath error:&error];
+        if (!contents)
+        {
+            NSLog(@"Error reading contents at \"%@\"", absolutePath);
+        }
+
+        if (contents.count == 0)
+        {
+            return PublishDirectoryDeletionRiskSafe;
+        }
+        else
+        {
+            return PublishDirectoryDeletionRiskNonEmptyDirectory;
+        }
+    }
+
+    return PublishDirectoryDeletionRiskSafe;
+}
+
+@end


### PR DESCRIPTION
If use custom zip directory is checked but no directory is chosen the default directory will be used.

Clicking on select for a custom directory won't render Sprite Builder useless: Cannot dismiss project settings dialog.

Fixes: https://github.com/spritebuilder/SpriteBuilder/issues/973
Implements feature: https://github.com/spritebuilder/SpriteBuilder/issues/865
