### PR TITLE
Fixing saving trim sprites for smart sprite sheets.

### DIFF
--- a/SpriteBuilder/SpriteBuilder Tests/ResourcePropertiesMigrator_Tests.m
+++ b/SpriteBuilder/SpriteBuilder Tests/ResourcePropertiesMigrator_Tests.m
@@ -50,7 +50,7 @@
     XCTAssertTrue([_projectSettings isDirtyRelPath:@"flowers"]);
 
     XCTAssertFalse([_projectSettings propertyForRelPath:@"rocks" andKey:RESOURCE_PROPERTY_LEGACY_KEEP_SPRITES_UNTRIMMED]);
-    XCTAssertTrue([_projectSettings propertyForRelPath:@"rocks" andKey:RESOURCE_PROPERTY_TRIM_SPRITES]);
+    XCTAssertFalse([_projectSettings propertyForRelPath:@"rocks" andKey:RESOURCE_PROPERTY_TRIM_SPRITES]);
     XCTAssertFalse([_projectSettings isDirtyRelPath:@"rocks"]);
 
     XCTAssertFalse([_projectSettings propertyForRelPath:@"background.png" andKey:RESOURCE_PROPERTY_LEGACY_KEEP_SPRITES_UNTRIMMED]);

--- a/SpriteBuilder/ccBuilder/ResourcePropertiesMigrator.m
+++ b/SpriteBuilder/ccBuilder/ResourcePropertiesMigrator.m
@@ -54,13 +54,17 @@
         return;
     }
 
-    if ([[_projectSettings propertyForRelPath:relPath andKey:RESOURCE_PROPERTY_LEGACY_KEEP_SPRITES_UNTRIMMED] boolValue])
+    NSNumber *trimSpritesValue = [_projectSettings propertyForRelPath:relPath andKey:RESOURCE_PROPERTY_LEGACY_KEEP_SPRITES_UNTRIMMED];
+    if (trimSpritesValue)
     {
-        [_projectSettings removePropertyForRelPath:relPath andKey:RESOURCE_PROPERTY_LEGACY_KEEP_SPRITES_UNTRIMMED];
-    }
-    else
-    {
-        [_projectSettings setProperty:@YES forRelPath:relPath andKey:RESOURCE_PROPERTY_TRIM_SPRITES];
+        if ([trimSpritesValue boolValue])
+        {
+            [_projectSettings removePropertyForRelPath:relPath andKey:RESOURCE_PROPERTY_LEGACY_KEEP_SPRITES_UNTRIMMED];
+        }
+        else
+        {
+            [_projectSettings setProperty:@YES forRelPath:relPath andKey:RESOURCE_PROPERTY_TRIM_SPRITES];
+        }
     }
 
     if (!dirtyMarked)


### PR DESCRIPTION
It's literarily impossible to migrate property values which are defined by absence.

Fixes https://github.com/spritebuilder/SpriteBuilder/issues/1085.
