### PR TITLE
Mac app delegate now has code for setting a default window size.

### DIFF
--- a/Support/PROJECTNAME.spritebuilder/Source/Platforms/Mac/AppDelegate.m
+++ b/Support/PROJECTNAME.spritebuilder/Source/Platforms/Mac/AppDelegate.m
@@ -15,6 +15,11 @@
     // enable FPS and SPF
     // [director setDisplayStats:YES];
 
+    // Set a default window size
+    CGSize defaultWindowSize = CGSizeMake(480.0f, 320.0f);
+    [self.window setFrame:CGRectMake(0.0f, 0.0f, defaultWindowSize.width, defaultWindowSize.height) display:true animate:false];
+    [self.glView setFrame:self.window.frame];
+
     // connect the OpenGL view with the director
     [director setView:self.glView];
 

--- a/Support/PROJECTNAME.spritebuilder/Source/Resources/Platforms/Mac/MainMenu.xib
+++ b/Support/PROJECTNAME.spritebuilder/Source/Resources/Platforms/Mac/MainMenu.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6245" systemVersion="13E28" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6250" systemVersion="14A389" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6245"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6250"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -669,9 +669,8 @@
         </menu>
         <window title="PROJECTNAME" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" animationBehavior="default" id="WbL-ZP-sg3">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
-            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="109" y="132" width="480" height="320"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1177"/>
             <view key="contentView" id="1Kl-CE-vX6">
                 <rect key="frame" x="0.0" y="0.0" width="480" height="320"/>
                 <autoresizingMask key="autoresizingMask"/>


### PR DESCRIPTION
Before this change, you needed to edit the xib to adjust the size of the window and view that opens up. I think that's easily missed by users. I've maintained the same size, but placed it in the Mac AppDelegate template, so it's easier for users to change.

There's probably a lot of other improvement to make for the Mac AppDelegate too.
