### PR TITLE
Fix #595 - remove RMResource children along with parent.

### DIFF
--- a/SpriteBuilder/ccBuilder/ResourceCommandController.m
+++ b/SpriteBuilder/ccBuilder/ResourceCommandController.m
@@ -90,7 +90,7 @@
 - (void)deleteResource:(id)sender
 {
     ResourceDeleteCommand *command = [[ResourceDeleteCommand alloc] init];
-    command.resources = [self selectedResources];
+    command.resources = [_resourceManagerOutlineView selectedResourceAndChildren];
     command.projectSettings = _projectSettings;
     command.outlineView = _resourceManagerOutlineView;
     command.resourceManager = _resourceManager;

--- a/SpriteBuilder/ccBuilder/ResourceManagerOutlineView.h
+++ b/SpriteBuilder/ccBuilder/ResourceManagerOutlineView.h
@@ -32,4 +32,5 @@
 
 - (NSArray *)selectedResources;
 
+- (NSArray *)selectedResourceAndChildren;
 @end

--- a/SpriteBuilder/ccBuilder/ResourceManagerOutlineView.m
+++ b/SpriteBuilder/ccBuilder/ResourceManagerOutlineView.m
@@ -23,7 +23,6 @@
 */
 
 #import "ResourceManagerOutlineView.h"
-#import "AppDelegate.h"
 #import "ResourceContextMenu.h"
 #import "ResourceCommandController.h"
 
@@ -126,7 +125,7 @@
         [_actionTarget deleteResource:nil];
         return;
     }
-    
+
     [super keyDown:theEvent];
 }
 
@@ -139,4 +138,32 @@
     }
 }
 
+- (NSArray *)selectedResourceAndChildren
+{
+    NSArray *selectedResources = [self selectedResources];
+    NSArray *resources = @[];
+
+    for(id resource in selectedResources)
+    {
+        resources = [resources arrayByAddingObjectsFromArray:[self childrenOfResource:resource]];
+    }
+
+    return resources;
+}
+
+- (NSArray *)childrenOfResource:(id)resource
+{
+    NSMutableArray *result = [NSMutableArray array];
+
+    NSInteger noOfChildren = [self.dataSource outlineView:self numberOfChildrenOfItem:resource];
+    for (int i = 0; i < noOfChildren; i++)
+    {
+        id child = [self.dataSource outlineView:self child:i ofItem:resource];
+        [result addObjectsFromArray:[self childrenOfResource:child]];
+    }
+
+    [result addObject:resource];
+
+    return result;
+}
 @end


### PR DESCRIPTION
This review is designed to address #595 

The child resources were not being correctly removed, which lead to the deleted scene remaining in the tab bar. When the project was saved the deleted scenes were being passed to `CFRelease` resulting in termination.

This patch fixes the problem by explicitly passing any and all child resources to the removal command.
