### PR TITLE
Fix #947 by updating inspector controller after templates are applied.

### DIFF
--- a/SpriteBuilder/ccBuilder/PropertyInspectorTemplateHandler.m
+++ b/SpriteBuilder/ccBuilder/PropertyInspectorTemplateHandler.m
@@ -10,6 +10,7 @@
 #import "AppDelegate.h"
 #import "PlugInNode.h"
 #import "PropertyInspectorTemplate.h"
+#import "InspectorController.h"
 
 @implementation PropertyInspectorTemplateHandler
 
@@ -87,6 +88,8 @@
         [particles stopSystem];
         [particles resetSystem];
     }
+
+    [[InspectorController sharedController] updateInspectorFromSelection];
 }
 
 - (void) installDefaultTemplatesReplace:(BOOL)replace


### PR DESCRIPTION
In #947 no properties were being updated after a template was applied. This patch tells the `PropertyInspectorTemplateHandler` to update the `InspectorController` after making changes to the selected node.
