### PR TITLE
Add validation for whitespace characters.

### DIFF
--- a/SpriteBuilder/ccBuilder/ResourceNewFileCommand.m
+++ b/SpriteBuilder/ccBuilder/ResourceNewFileCommand.m
@@ -75,7 +75,8 @@
 {
     BOOL isLongEnough;
     NSString *withoutFileExtension = [name stringByReplacingOccurrencesOfString:@".ccb" withString:@""];
-    isLongEnough = withoutFileExtension.length >= MINIMUM_FILENAME_LENGTH;
+    NSString *withoutWhitespace = [withoutFileExtension stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    isLongEnough = withoutWhitespace.length >= MINIMUM_FILENAME_LENGTH;
 
     BOOL firstCharIsDot = [[name substringWithRange:(NSRange) {.location = 0, .length = 1}] isEqualToString:@"."];
 


### PR DESCRIPTION
This is designed to address #1109 by validation that a filename contains more than a minimum number of non-whitespace characters.
