### PR TITLE
Fix #1146 by keeping result of outline view delegate method within range...

### DIFF
--- a/SpriteBuilder/ccBuilder/SequencerHandler.m
+++ b/SpriteBuilder/ccBuilder/SequencerHandler.m
@@ -374,7 +374,15 @@ static SequencerHandler* sharedSequencerHandler;
     }
 
     CCNode* node = (CCNode*)item;
-    return [node children][(NSUInteger) index];
+
+    if (index < node.children.count)
+    {
+        return [node children][(NSUInteger) index];
+    }
+    else
+    {
+        return nil;
+    }
 }
 
 - (id)outlineView:(NSOutlineView *)outlineView objectValueForTableColumn:(NSTableColumn *)tableColumn byItem:(id)item


### PR DESCRIPTION
The data source protocol method on the `SequenceHandler` was trying to return values outside of the range of an array when the outline view was being manipulated during arrangement reordering operations.

This PR just enforces the limits of the array, returning nil when given an invalid index, and fixes the crash described.
