### PR TITLE
Fix crash when hammering the animation scrubber with clicks.

### DIFF
--- a/SpriteBuilder/ccBuilder/SequencerScrubberSelectionView.m
+++ b/SpriteBuilder/ccBuilder/SequencerScrubberSelectionView.m
@@ -80,15 +80,17 @@
     }
     else if (row == kCCBRowNone)
     {
-        CCNode* lastNode = [outlineView itemAtRow:[outlineView numberOfRows]-1];
-        if (lastNode.seqExpanded)
+        id lastItem = [outlineView itemAtRow:[outlineView numberOfRows]-1];
+        if ([lastItem isKindOfClass:[CCNode class]])
         {
-            return [[[lastNode plugIn] animatablePropertiesForNode:lastNode] count]-1;
+            CCNode *lastNode = (CCNode*)lastItem;
+            if(lastNode.seqExpanded)
+            {
+                return [[[lastNode plugIn] animatablePropertiesForNode:lastNode] count] - 1;
+            }
         }
-        else
-        {
-            return 0;
-        }
+
+        return 0;
     }
     
     NSRect cellFrame = [outlineView frameOfCellAtColumn:0 row:row];


### PR DESCRIPTION
I found a crash when playing with animations in the editor.

`lastNode` is assumed to always be a descendant of `CCNode`, which isn't the case (the OutlineView also contains `SequencerJoints`). This results in an unrecognised selector exception which crashes the app. This PR fixes that by explicitly checking class membership after getting the item back from the view.
