### PR TITLE
Bugfix: Node connections stopped working.

### DIFF
--- a/SpriteBuilder/ccBuilder/EffectViewController.h
+++ b/SpriteBuilder/ccBuilder/EffectViewController.h
@@ -14,4 +14,7 @@
 
 @property (nonatomic) id<EffectProtocol> effect;
 @property (nonatomic) BOOL highlight;
+
+- (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil effect:(id<EffectProtocol>)effect;
+
 @end

--- a/SpriteBuilder/ccBuilder/EffectViewController.m
+++ b/SpriteBuilder/ccBuilder/EffectViewController.m
@@ -14,12 +14,14 @@
 
 @implementation EffectViewController
 @synthesize highlight;
-- (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
+
+- (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil effect:(id<EffectProtocol>)effect
 {
     self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
-    if (self) {
-        [self.view setWantsLayer:YES];
-
+    if (self)
+    {
+        self.effect = effect;
+        [self.view setWantsLayer:YES];        
     }
     return self;
 }
@@ -34,7 +36,7 @@
 		[viewLayer setBackgroundColor:CGColorCreateGenericRGB(0.8f, 0.87f, 0.92f, 1.0f)];
 	else
 		[viewLayer setBackgroundColor:CGColorCreateGenericRGB(0.0f, 0.0f, 0.0f, 0.0f)];
-	
+    
 	[self.view setLayer:viewLayer];
 }
 

--- a/SpriteBuilder/ccBuilder/InspectorEffectControl.m
+++ b/SpriteBuilder/ccBuilder/InspectorEffectControl.m
@@ -120,9 +120,8 @@
 		id<EffectProtocol> effect =  [self.effectNode effects][i];
 
 		Class viewControllerClass = NSClassFromString(effectDescription.viewController);
-		EffectViewController * vc = [((EffectViewController*)[viewControllerClass alloc]) initWithNibName:effectDescription.viewController bundle:[NSBundle mainBundle]];
+        EffectViewController * vc = [((EffectViewController*)[viewControllerClass alloc]) initWithNibName:effectDescription.viewController bundle:[NSBundle mainBundle] effect:effect];
 
-		vc.effect =	effect;
 		[viewControllers addObject:vc];
 	}
 


### PR DESCRIPTION
As of commit d09c53bbeae43504718f866b26a526a26c2618a6 the drag and drop node connection stopped to work.
This was a concurrency issue, a wonder it worked in the first place.
Descendants of EffectViewController were accessing effects property in awakeFromNib which was set AFTER using the initializer it in InspectorEffectControl. Due to a draw call awakefromnib was delayed and the setter was used before the initializer of EffectViewController was executed.
Solution: Custom initializer accepting the effect value.
