### PR TITLE
Don't implicitly treat outline items as CCNode instances.

### DIFF
--- a/SpriteBuilder/ccBuilder/SequencerScrubberSelectionView.m
+++ b/SpriteBuilder/ccBuilder/SequencerScrubberSelectionView.m
@@ -467,7 +467,7 @@
             SequencerChannel* channel = item;
             [selectedKeyframes addObjectsFromArray:[channel.seqNodeProp keyframesBetweenMinTime:xMinTime maxTime:xMaxTime]];
         }
-        else
+        else if ([item isKindOfClass:[CCNode class]])
         {
             CCNode* node = item;
             for (int subRow = yMinSubRow; subRow <= yMaxSubRow; subRow++)


### PR DESCRIPTION
This is another patch designed to fix a crash encountered within the scrubber view. Objects are being treated implicitly as CCNode instances when they are returned as type `id` from the OutlineView. This results in the crash below.

```
2014-12-08 18:30:35.388 SpriteBuilder[25776:222178] -[SequencerJoints plugIn]: unrecognized selector sent to instance 0x7fd17b6b3000
2014-12-08 18:30:38.956 SpriteBuilder[25776:222178] -[SequencerJoints plugIn]: unrecognized selector sent to instance 0x7fd17b6b3000
2014-12-08 18:30:38.957 SpriteBuilder[25776:222178] (
    0   CoreFoundation                      0x00007fff9084864c __exceptionPreprocess + 172
    1   libobjc.A.dylib                     0x00007fff8b4fe6de objc_exception_throw + 43
    2   CoreFoundation                      0x00007fff9084b6bd -[NSObject(NSObject) doesNotRecognizeSelector:] + 205
    3   CoreFoundation                      0x00007fff90792a84 ___forwarding___ + 1028
    4   CoreFoundation                      0x00007fff907925f8 _CF_forwarding_prep_0 + 120
    5   SpriteBuilder                       0x000000010377a7e7 -[SequencerScrubberSelectionView propNameForNode:subRow:] + 55
    6   SpriteBuilder                       0x000000010377b5c2 -[SequencerScrubberSelectionView keyframesInSelectionArea] + 2084
    7   SpriteBuilder                       0x000000010377ccaa -[SequencerScrubberSelectionView mouseUp:] + 839
    8   AppKit                              0x00007fff9019802b -[NSWindow _reallySendEvent:] + 759
    9   AppKit                              0x00007fff8fc2550c -[NSWindow sendEvent:] + 368
    10  AppKit                              0x00007fff8fbd7096 -[NSApplication sendEvent:] + 2238
    11  AppKit                              0x00007fff8fa63e98 -[NSApplication run] + 711
    12  AppKit                              0x00007fff8fa4f2d4 NSApplicationMain + 1832
    13  libdyld.dylib                       0x00007fff8bc255c9 start + 1
    14  ???                                 0x0000000000000001 0x0 + 1
)
```

This is a simple check to test class membership before accessing CCNode members.
