### PR TITLE
Improve image preview performance

### DIFF
--- a/SpriteBuilder/SpriteBuilder.xcodeproj/project.pbxproj
+++ b/SpriteBuilder/SpriteBuilder.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		58FA2034162D73F3006B8856 /* TB_bottomPanel.png in Resources */ = {isa = PBXBuildFile; fileRef = 58FA2031162D73F3006B8856 /* TB_bottomPanel.png */; };
 		58FA2035162D73F3006B8856 /* TB_leftPanel.png in Resources */ = {isa = PBXBuildFile; fileRef = 58FA2032162D73F3006B8856 /* TB_leftPanel.png */; };
 		58FA2036162D73F3006B8856 /* TB_rightPanel.png in Resources */ = {isa = PBXBuildFile; fileRef = 58FA2033162D73F3006B8856 /* TB_rightPanel.png */; };
+		5B321CC91A5B458800A7C779 /* QuickLook.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B321CC81A5B458800A7C779 /* QuickLook.framework */; };
 		5BA3DC35192110B90055DD96 /* GuideGridSizeWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BA3DC30192108AB0055DD96 /* GuideGridSizeWindow.m */; };
 		5BA3DC36192110BA0055DD96 /* GuideGridSizeWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5BA3DC31192108AB0055DD96 /* GuideGridSizeWindow.xib */; };
 		5BB9A3551A038C59008184AE /* ResourceDuplicateCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BB9A3541A038C59008184AE /* ResourceDuplicateCommand.m */; };
@@ -1319,6 +1320,7 @@
 		58FA2031162D73F3006B8856 /* TB_bottomPanel.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = TB_bottomPanel.png; sourceTree = "<group>"; };
 		58FA2032162D73F3006B8856 /* TB_leftPanel.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = TB_leftPanel.png; sourceTree = "<group>"; };
 		58FA2033162D73F3006B8856 /* TB_rightPanel.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = TB_rightPanel.png; sourceTree = "<group>"; };
+		5B321CC81A5B458800A7C779 /* QuickLook.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuickLook.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/System/Library/Frameworks/QuickLook.framework; sourceTree = DEVELOPER_DIR; };
 		5BA3DC2F192108AB0055DD96 /* GuideGridSizeWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GuideGridSizeWindow.h; sourceTree = "<group>"; };
 		5BA3DC30192108AB0055DD96 /* GuideGridSizeWindow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GuideGridSizeWindow.m; sourceTree = "<group>"; };
 		5BA3DC31192108AB0055DD96 /* GuideGridSizeWindow.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = GuideGridSizeWindow.xib; sourceTree = "<group>"; };
@@ -2809,6 +2811,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5B321CC91A5B458800A7C779 /* QuickLook.framework in Frameworks */,
 				7B76CF8619F1AF9E006AF235 /* libcocos2d-mac.a in Frameworks */,
 				D35E589E18E391DA008571EC /* GLKit.framework in Frameworks */,
 				80AD79A21863878B00B653B7 /* libPVRTexLib.a in Frameworks */,
@@ -3666,6 +3669,7 @@
 		7789ABC1133AA82000CEFCC7 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				5B321CC81A5B458800A7C779 /* QuickLook.framework */,
 				830F4EB019347032002B832D /* OCMock.framework */,
 				D35E589D18E391DA008571EC /* GLKit.framework */,
 				D2E0168418D783C900927430 /* AppleScriptKit.framework */,

--- a/SpriteBuilder/ccBuilder/RMResource.h
+++ b/SpriteBuilder/ccBuilder/RMResource.h
@@ -16,6 +16,7 @@
 - (void)loadData;
 
 - (NSImage *)previewForResolution:(NSString *)res;
+- (NSString*)absoluteResolutionPath:(NSString *)res;
 
 // Convenience method until SB uses kCCBResTypeSpriteSheet as type, which is never set
 - (BOOL)isSpriteSheet;

--- a/SpriteBuilder/ccBuilder/RMResource.h
+++ b/SpriteBuilder/ccBuilder/RMResource.h
@@ -16,7 +16,7 @@
 - (void)loadData;
 
 - (NSImage *)previewForResolution:(NSString *)res;
-- (NSString*)absoluteResolutionPath:(NSString *)res;
+- (NSString*)absoluteAutoPathForResolution:(NSString *)res;
 
 // Convenience method until SB uses kCCBResTypeSpriteSheet as type, which is never set
 - (BOOL)isSpriteSheet;

--- a/SpriteBuilder/ccBuilder/RMResource.m
+++ b/SpriteBuilder/ccBuilder/RMResource.m
@@ -71,21 +71,30 @@
 
 - (NSImage*) previewForResolution:(NSString *)res
 {
-    if (!res) res = @"auto";
+    
+    NSString* autoPath = [self absoluteResolutionPath:res];
+    if(!autoPath) return NULL;
+    
+    NSImage* img = [[NSImage alloc] initWithContentsOfFile:[self absoluteResolutionPath:autoPath]];
+    return img;
+}
 
+- (NSString*)absoluteResolutionPath:(NSString *)res {
+    
+    if (!res) res = @"auto";
+    
     if (_type == kCCBResTypeImage)
     {
         NSString* fileName = [_filePath lastPathComponent];
         NSString* dirPath = [_filePath stringByDeletingLastPathComponent];
         NSString* resDirName = [@"resources-" stringByAppendingString:res];
-
+        
         NSString* autoPath = [[dirPath stringByAppendingPathComponent:resDirName] stringByAppendingPathComponent:fileName];
-
-        NSImage* img = [[NSImage alloc] initWithContentsOfFile:autoPath];
-        return img;
+        
+        return autoPath;
     }
-
-    return NULL;
+    
+    return nil;
 }
 
 - (NSComparisonResult) compare:(id) obj

--- a/SpriteBuilder/ccBuilder/RMResource.m
+++ b/SpriteBuilder/ccBuilder/RMResource.m
@@ -72,14 +72,13 @@
 - (NSImage*) previewForResolution:(NSString *)res
 {
     
-    NSString* autoPath = [self absoluteResolutionPath:res];
+    NSString* autoPath = [self absoluteAutoPathForResolution:res];
     if(!autoPath) return NULL;
     
-    NSImage* img = [[NSImage alloc] initWithContentsOfFile:[self absoluteResolutionPath:autoPath]];
-    return img;
+    return [[NSImage alloc] initWithContentsOfFile:autoPath];
 }
 
-- (NSString*)absoluteResolutionPath:(NSString *)res {
+- (NSString*)absoluteAutoPathForResolution:(NSString *)res {
     
     if (!res) res = @"auto";
     
@@ -89,9 +88,8 @@
         NSString* dirPath = [_filePath stringByDeletingLastPathComponent];
         NSString* resDirName = [@"resources-" stringByAppendingString:res];
         
-        NSString* autoPath = [[dirPath stringByAppendingPathComponent:resDirName] stringByAppendingPathComponent:fileName];
+        return [[dirPath stringByAppendingPathComponent:resDirName] stringByAppendingPathComponent:fileName];
         
-        return autoPath;
     }
     
     return nil;

--- a/SpriteBuilder/ccBuilder/ResourceManager.h
+++ b/SpriteBuilder/ccBuilder/ResourceManager.h
@@ -32,6 +32,7 @@
 @class RMPackage;
 
 #define kCCBMaxTrackedDirectories 500
+#define kRMImagePreviewSize       32.0
 
 
 @interface ResourceManager : NSObject <SCEventListenerProtocol>

--- a/SpriteBuilder/ccBuilder/ResourceManagerUtil.h
+++ b/SpriteBuilder/ccBuilder/ResourceManagerUtil.h
@@ -26,7 +26,7 @@
 
 @class RMResource;
 
-@interface ResourceManagerUtil : NSObject
+@interface ResourceManagerUtil : NSObject <NSMenuDelegate>
 
 + (void) populateResourcePopup:(NSPopUpButton*)popup resType:(int)resType allowSpriteFrames:(BOOL)allowSpriteFrames selectedFile:(NSString*)file selectedSheet:(NSString*) sheetFile target:(id)target;
 

--- a/SpriteBuilder/ccBuilder/ResourceManagerUtil.m
+++ b/SpriteBuilder/ccBuilder/ResourceManagerUtil.m
@@ -73,7 +73,7 @@
     [self setTitle:str forPopup:popup forceMarker:NO];
 }
 
-+ (NSInteger) addDirectory: (RMDirectory*) dir ToMenu: (NSMenu*) menu target:(id)target resType:(int) resType allowSpriteFrames:(BOOL) allowSpriteFrames
++ (NSInteger) addDirectory: (RMDirectory*) dir toMenu: (NSMenu*) menu target:(id)target resType:(int) resType allowSpriteFrames:(BOOL) allowSpriteFrames
 {
     NSArray* arr = [dir resourcesForType:resType];
     NSInteger count = 0; // Valid Assets Added
@@ -154,7 +154,7 @@
                 
                 NSMenu* subMenu = [[NSMenu alloc] initWithTitle:itemName];
                 
-                count=[ResourceManagerUtil addDirectory:subDir ToMenu:subMenu target:target resType:resType allowSpriteFrames:allowSpriteFrames];
+                count=[ResourceManagerUtil addDirectory:subDir toMenu:subMenu target:target resType:resType allowSpriteFrames:allowSpriteFrames];
                 
                 if(count) {
                     NSMenuItem* menuItem = [[NSMenuItem alloc] initWithTitle:itemName action:NULL keyEquivalent:@""];
@@ -195,7 +195,7 @@
         // There is only a single active directory, make its contents the top level
         RMDirectory* activeDir = [rm.activeDirectories objectAtIndex:0];
     
-        [ResourceManagerUtil addDirectory:activeDir ToMenu:menu target:target resType: resType allowSpriteFrames:allowSpriteFrames];
+        [ResourceManagerUtil addDirectory:activeDir toMenu:menu target:target resType: resType allowSpriteFrames:allowSpriteFrames];
     }
     else
     {
@@ -207,7 +207,7 @@
             
             NSMenu* subMenu = [[NSMenu alloc] initWithTitle:itemName];
             
-            [ResourceManagerUtil addDirectory:activeDir ToMenu:subMenu target:target resType:resType allowSpriteFrames:allowSpriteFrames];
+            [ResourceManagerUtil addDirectory:activeDir toMenu:subMenu target:target resType:resType allowSpriteFrames:allowSpriteFrames];
             
             NSMenuItem* menuItem = [[NSMenuItem alloc] initWithTitle:itemName action:NULL keyEquivalent:@""];
             [menu addItem:menuItem];
@@ -317,12 +317,9 @@
 
 + (NSImage*) thumbnailImageForResource:(RMResource*)res {
 
-    NSString* path = [res absoluteResolutionPath:nil];
-    
+    NSString* path = [res absoluteAutoPathForResolution:nil];
     CGFloat viewScale = [AppDelegate appDelegate].derivedViewScaleFactor;
-    
     CGSize size = CGSizeMake(kRMImagePreviewSize*viewScale, kRMImagePreviewSize*viewScale);
-
     NSURL *fileURL = [NSURL fileURLWithPath:path];
     
     if (!path|| !fileURL) {
@@ -333,23 +330,20 @@
                                             (__bridge CFURLRef)fileURL,
                                             CGSizeMake(size.width, size.height),
                                             nil);
+    NSImage *newImage = nil;
     
     if (ref != NULL) {
         NSBitmapImageRep *bitmapImageRep = [[NSBitmapImageRep alloc] initWithCGImage:ref];
-        NSImage *newImage = nil;
         
         if (bitmapImageRep) {
             newImage = [[NSImage alloc] initWithSize:[bitmapImageRep size]];
             [newImage addRepresentation:bitmapImageRep];
-            CFRelease(ref);
-            
-            if (newImage) {
-                return newImage;
-            }
         }
+        
+        CFRelease(ref);
     }
     
-    return nil;
+    return newImage;
 }
 
 + (NSImage*) smallIconForFile:(NSString*)file


### PR DESCRIPTION
Related #1242 

Using QuickLook for preview generation, fast even on big images.
Quick refactor for grabbing full image resource paths
No lag on node selection, previews are now created on-demand when dropdown is selected.
