### PR TITLE
Update Android templates for use with apportable

### DIFF
--- a/SpriteBuilder/ccBuilder/CCBProjectCreator.m
+++ b/SpriteBuilder/ccBuilder/CCBProjectCreator.m
@@ -147,43 +147,31 @@
     [self setName:projName inFile:xibFileName search:substitutableProjectName];
 
     // Android
-    NSString* activityJavaFileName = [parentPath stringByAppendingPathComponent:[NSString stringWithFormat:@"Source/Platforms/Android/java/org/cocos2d/%@/%@Activity.java", substitutableProjectIdentifier, substitutableProjectIdentifier]];
-    if ([fm fileExistsAtPath:activityJavaFileName])
+    NSString* activityMFileName = [parentPath stringByAppendingPathComponent:[NSString stringWithFormat:@"Source/Platforms/Android/%@Activity.m", substitutableProjectIdentifier]];
+    if ([fm fileExistsAtPath:activityMFileName])
     {
-        NSString* resultActivityJavaFileName = [parentPath stringByAppendingPathComponent:[NSString stringWithFormat:@"Source/Platforms/Android/java/org/cocos2d/%@/%@Activity.java", identifier, identifier]];
-        
-        if (![fm createDirectoryAtPath:[resultActivityJavaFileName stringByDeletingLastPathComponent] withIntermediateDirectories:YES attributes:nil error:&error]) {
-            return NO;
-        }
-        
-        if (![fm moveItemAtPath:activityJavaFileName toPath:resultActivityJavaFileName error:&error]) {
-            return NO;
-        }
-        [self setName:identifier inFile:resultActivityJavaFileName search:substitutableProjectIdentifier];
-        
-        NSString* activityMFileName = [parentPath stringByAppendingPathComponent:[NSString stringWithFormat:@"Source/Platforms/Android/%@Activity.m", substitutableProjectIdentifier]];
         NSString* resultActivityMFileName = [parentPath stringByAppendingPathComponent:[NSString stringWithFormat:@"Source/Platforms/Android/%@Activity.m", identifier]];
-        
+
         if (![fm moveItemAtPath:activityMFileName toPath:resultActivityMFileName error:&error]) {
             return NO;
         }
-        
+
         [self setName:identifier inFile:resultActivityMFileName search:substitutableProjectIdentifier];
-        
+
         NSString* activityHFileName = [parentPath stringByAppendingPathComponent:[NSString stringWithFormat:@"Source/Platforms/Android/%@Activity.h", substitutableProjectIdentifier]];
         NSString* resultActivityHFileName = [parentPath stringByAppendingPathComponent:[NSString stringWithFormat:@"Source/Platforms/Android/%@Activity.h", identifier]];
-        
+
         if (![fm moveItemAtPath:activityHFileName toPath:resultActivityHFileName error:&error]) {
             return NO;
         }
-        
+
         [self setName:identifier inFile:resultActivityHFileName search:substitutableProjectIdentifier];
-        
+
         NSString* manifestFileName = [parentPath stringByAppendingPathComponent:@"Source/Resources/Platforms/Android/AndroidManifest.xml"];
         [self setName:identifier inFile:manifestFileName search:substitutableProjectIdentifier];
         [self setName:projName inFile:manifestFileName search:substitutableProjectName];
     }
-	
+
 	// perform cleanup to remove unnecessary files which only bloat the project
 	[CCBFileUtil cleanupSpriteBuilderProjectAtPath:fileName];
 	

--- a/Support/PROJECTNAME.spritebuilder/PROJECTNAME.xcodeproj/project.pbxproj
+++ b/Support/PROJECTNAME.spritebuilder/PROJECTNAME.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		5B12102A197484DD004C1E1D /* PROJECTIDENTIFIERActivity.java in Sources */ = {isa = PBXBuildFile; fileRef = 5B12101B19748413004C1E1D /* PROJECTIDENTIFIERActivity.java */; };
 		5B121030197484FA004C1E1D /* PROJECTIDENTIFIERActivity.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B12102F197484FA004C1E1D /* PROJECTIDENTIFIERActivity.m */; };
 		5B121038197487F2004C1E1D /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = B737893E1807617C0076A88C /* AppDelegate.m */; };
 		7A046D7919E84ED5004C4763 /* MainScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A046D7519E84C36004C4763 /* MainScene.swift */; };
@@ -97,17 +96,9 @@
 		BC5399DA1A44DCC90063F482 /* GLActivityKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC5399D51A44DCC90063F482 /* GLActivityKit.framework */; };
 		BC5399DB1A44DCC90063F482 /* JavaFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC5399D61A44DCC90063F482 /* JavaFoundation.framework */; };
 		BC5399DC1A44DCC90063F482 /* JavaKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC5399D71A44DCC90063F482 /* JavaKit.framework */; };
-		BCD00A8C1A44E83400DA5AD0 /* CoreJava.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC5399D41A44DCC90063F482 /* CoreJava.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		5B121031197485D1004C1E1D /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B77F1B2617B978D7009739AE /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 5B121020197484A3004C1E1D;
-			remoteInfo = "PROJECTNAME Java";
-		};
 		7A9790FD19E62E40001FFC4D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B7378940180761A80076A88C /* cocos2d.xcodeproj */;
@@ -122,26 +113,12 @@
 			remoteGlobalIDString = D2FEB74F194F6C9E00FC0574;
 			remoteInfo = cocos2dAndroid;
 		};
-		7A97910119E62E40001FFC4D /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B7378940180761A80076A88C /* cocos2d.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 5BF3267A195F8D8800D9A51A;
-			remoteInfo = cocos2dJava;
-		};
 		7A97910319E62E40001FFC4D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B7378940180761A80076A88C /* cocos2d.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 7A4037A819E37038007B6E8F;
 			remoteInfo = "cocos2d-mac";
-		};
-		7A97910519E62E4C001FFC4D /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B7378940180761A80076A88C /* cocos2d.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 5BF32679195F8D8800D9A51A;
-			remoteInfo = cocos2dJava;
 		};
 		7A97910F19E6319A001FFC4D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -156,13 +133,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 7A4037A719E37038007B6E8F;
 			remoteInfo = "cocos2d-mac";
-		};
-		7A97911F19E63219001FFC4D /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = B7378940180761A80076A88C /* cocos2d.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 5BF32679195F8D8800D9A51A;
-			remoteInfo = cocos2dJava;
 		};
 		7A97912119E6321C001FFC4D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -180,8 +150,6 @@
 		5B121011197483EE004C1E1D /* ic_launcher.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = ic_launcher.png; sourceTree = "<group>"; };
 		5B121013197483EE004C1E1D /* ic_launcher.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = ic_launcher.png; sourceTree = "<group>"; };
 		5B121015197483EE004C1E1D /* ic_launcher.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = ic_launcher.png; sourceTree = "<group>"; };
-		5B12101B19748413004C1E1D /* PROJECTIDENTIFIERActivity.java */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.java; name = PROJECTIDENTIFIERActivity.java; path = Source/Platforms/Android/java/org/cocos2d/PROJECTIDENTIFIER/PROJECTIDENTIFIERActivity.java; sourceTree = "<group>"; };
-		5B121021197484A3004C1E1D /* PROJECTNAME Java.jar */ = {isa = PBXFileReference; explicitFileType = compiled.java.jar; includeInIndex = 0; path = "PROJECTNAME Java.jar"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5B12102E197484FA004C1E1D /* PROJECTIDENTIFIERActivity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PROJECTIDENTIFIERActivity.h; path = Source/Platforms/Android/PROJECTIDENTIFIERActivity.h; sourceTree = "<group>"; };
 		5B12102F197484FA004C1E1D /* PROJECTIDENTIFIERActivity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PROJECTIDENTIFIERActivity.m; path = Source/Platforms/Android/PROJECTIDENTIFIERActivity.m; sourceTree = "<group>"; };
 		5B121033197485FE004C1E1D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = Platforms/Android/Info.plist; sourceTree = "<group>"; };
@@ -245,14 +213,6 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		5B121028197484D5004C1E1D /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BCD00A8C1A44E83400DA5AD0 /* CoreJava.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		7A4035FC19DDEE84007B6E8F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -375,7 +335,6 @@
 		7A40362219DDF090007B6E8F /* Android */ = {
 			isa = PBXGroup;
 			children = (
-				5B12101B19748413004C1E1D /* PROJECTIDENTIFIERActivity.java */,
 				5B12102E197484FA004C1E1D /* PROJECTIDENTIFIERActivity.h */,
 				5B12102F197484FA004C1E1D /* PROJECTIDENTIFIERActivity.m */,
 			);
@@ -448,7 +407,6 @@
 			children = (
 				7A9790FE19E62E40001FFC4D /* libcocos2d.a */,
 				7A97910019E62E40001FFC4D /* libcocos2dAndroid.a */,
-				7A97910219E62E40001FFC4D /* cocos2dJava.jar */,
 				7A97910419E62E40001FFC4D /* libcocos2d-mac.a */,
 			);
 			name = Products;
@@ -521,7 +479,6 @@
 			children = (
 				B77F1B2E17B978D7009739AE /* PROJECTNAME.app */,
 				927F61BF196C771E000F43EF /* PROJECTNAME Android.app */,
-				5B121021197484A3004C1E1D /* PROJECTNAME Java.jar */,
 				7A4035FF19DDEE84007B6E8F /* PROJECTNAME Mac.app */,
 			);
 			name = Products;
@@ -583,23 +540,6 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		5B121020197484A3004C1E1D /* PROJECTNAME Java */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 5B121022197484A3004C1E1D /* Build configuration list for PBXNativeTarget "PROJECTNAME Java" */;
-			buildPhases = (
-				5B121027197484D2004C1E1D /* Sources */,
-				5B121028197484D5004C1E1D /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				7A97910619E62E4C001FFC4D /* PBXTargetDependency */,
-			);
-			name = "PROJECTNAME Java";
-			productName = "PROJECTNAME Java";
-			productReference = 5B121021197484A3004C1E1D /* PROJECTNAME Java.jar */;
-			productType = "com.apportable.java.product-type.library";
-		};
 		7A4035FE19DDEE84007B6E8F /* PROJECTNAME Mac */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7A40361E19DDEE84007B6E8F /* Build configuration list for PBXNativeTarget "PROJECTNAME Mac" */;
@@ -631,8 +571,6 @@
 			);
 			dependencies = (
 				7A97912219E6321C001FFC4D /* PBXTargetDependency */,
-				7A97912019E63219001FFC4D /* PBXTargetDependency */,
-				5B121032197485D1004C1E1D /* PBXTargetDependency */,
 			);
 			name = "PROJECTNAME Android";
 			productName = Example;
@@ -701,7 +639,6 @@
 			targets = (
 				B77F1B2D17B978D7009739AE /* PROJECTNAME iOS */,
 				927F6198196C771E000F43EF /* PROJECTNAME Android */,
-				5B121020197484A3004C1E1D /* PROJECTNAME Java */,
 				7A4035FE19DDEE84007B6E8F /* PROJECTNAME Mac */,
 			);
 		};
@@ -720,13 +657,6 @@
 			fileType = archive.ar;
 			path = libcocos2dAndroid.a;
 			remoteRef = 7A9790FF19E62E40001FFC4D /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		7A97910219E62E40001FFC4D /* cocos2dJava.jar */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.jar;
-			path = cocos2dJava.jar;
-			remoteRef = 7A97910119E62E40001FFC4D /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		7A97910419E62E40001FFC4D /* libcocos2d-mac.a */ = {
@@ -854,14 +784,6 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		5B121027197484D2004C1E1D /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				5B12102A197484DD004C1E1D /* PROJECTIDENTIFIERActivity.java in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		7A4035FB19DDEE84007B6E8F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -896,16 +818,6 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		5B121032197485D1004C1E1D /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 5B121020197484A3004C1E1D /* PROJECTNAME Java */;
-			targetProxy = 5B121031197485D1004C1E1D /* PBXContainerItemProxy */;
-		};
-		7A97910619E62E4C001FFC4D /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = cocos2dJava;
-			targetProxy = 7A97910519E62E4C001FFC4D /* PBXContainerItemProxy */;
-		};
 		7A97911019E6319A001FFC4D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "cocos2d-ios";
@@ -916,11 +828,6 @@
 			name = "cocos2d-mac";
 			targetProxy = 7A97911519E631A1001FFC4D /* PBXContainerItemProxy */;
 		};
-		7A97912019E63219001FFC4D /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = cocos2dJava;
-			targetProxy = 7A97911F19E63219001FFC4D /* PBXContainerItemProxy */;
-		};
 		7A97912219E6321C001FFC4D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = cocos2dAndroid;
@@ -929,74 +836,6 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		5B121023197484A3004C1E1D /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COMBINE_HIDPI_IMAGES = YES;
-				COPY_PHASE_STRIP = NO;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				MACOSX_DEPLOYMENT_TARGET = "$(inherited)";
-				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = sbandroid;
-			};
-			name = Debug;
-		};
-		5B121024197484A3004C1E1D /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COMBINE_HIDPI_IMAGES = YES;
-				COPY_PHASE_STRIP = YES;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				ENABLE_NS_ASSERTIONS = NO;
-				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				MACOSX_DEPLOYMENT_TARGET = "$(inherited)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = sbandroid;
-			};
-			name = Release;
-		};
 		7A40361919DDEE84007B6E8F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1318,15 +1157,6 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		5B121022197484A3004C1E1D /* Build configuration list for PBXNativeTarget "PROJECTNAME Java" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				5B121023197484A3004C1E1D /* Debug */,
-				5B121024197484A3004C1E1D /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		7A40361E19DDEE84007B6E8F /* Build configuration list for PBXNativeTarget "PROJECTNAME Mac" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Support/PROJECTNAME.spritebuilder/Source/Platforms/Android/PROJECTIDENTIFIERActivity.h
+++ b/Support/PROJECTNAME.spritebuilder/Source/Platforms/Android/PROJECTIDENTIFIERActivity.h
@@ -25,7 +25,7 @@
 
 #import "CCActivity.h"
 
-BRIDGE_CLASS("org.cocos2d.PROJECTIDENTIFIER.PROJECTIDENTIFIERActivity")
+BRIDGE_CLASS("com.apportable.GLActivity")
 @interface PROJECTIDENTIFIERActivity : CCActivity
 
 @end

--- a/Support/PROJECTNAME.spritebuilder/Source/Platforms/Android/PROJECTIDENTIFIERActivity.m
+++ b/Support/PROJECTNAME.spritebuilder/Source/Platforms/Android/PROJECTIDENTIFIERActivity.m
@@ -24,6 +24,8 @@
 
 
 #import "PROJECTIDENTIFIERActivity.h"
+#import <AndroidKit/AndroidKeyEvent.h>
+
 
 @implementation PROJECTIDENTIFIERActivity
 

--- a/Support/PROJECTNAME.spritebuilder/Source/Platforms/Android/java/org/cocos2d/PROJECTIDENTIFIER/PROJECTIDENTIFIERActivity.java
+++ b/Support/PROJECTNAME.spritebuilder/Source/Platforms/Android/java/org/cocos2d/PROJECTIDENTIFIER/PROJECTIDENTIFIERActivity.java
@@ -1,7 +1,0 @@
-package org.cocos2d.PROJECTIDENTIFIER;
-
-import org.cocos2d.CCActivity;
-
-public class PROJECTIDENTIFIERActivity extends CCActivity {
-
-}

--- a/Support/PROJECTNAME.spritebuilder/Source/Resources/Platforms/Android/AndroidManifest.xml
+++ b/Support/PROJECTNAME.spritebuilder/Source/Resources/Platforms/Android/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:debuggable="true"
         android:icon="@drawable/ic_launcher">
         <activity   
-            android:name="org.cocos2d.PROJECTIDENTIFIER.PROJECTIDENTIFIERActivity"
+            android:name="com.apportable.GLActivity"
             android:label="PROJECTNAME"
             android:screenOrientation="sensorLandscape"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|screenLayout|fontScale|uiMode|orientation|screenSize|smallestScreenSize"


### PR DESCRIPTION
This review does 3 things for compatibility with the latest apportable SDK.
1. Removes `.java` files and targets 
2. Updates the android templates
3. Updates the cocos2d submodule to point to a ref with the appropriate changes.
