### PR TITLE
InspectorFloat - Add support for simple range checking

### DIFF
--- a/SpriteBuilder/CCLightNode/CCBPProperties.plist
+++ b/SpriteBuilder/CCLightNode/CCBPProperties.plist
@@ -81,6 +81,8 @@
 			<string>Float</string>
 			<key>name</key>
 			<string>intensity</string>
+			<key>extra</key>
+			<string>min|0|max|1</string>
 		</dict>
 		<dict>
 			<key>animatable</key>
@@ -119,6 +121,8 @@
 			<string>Float</string>
 			<key>name</key>
 			<string>specularIntensity</string>
+			<key>extra</key>
+			<string>min|0|max|1</string>
 		</dict>
 		<dict>
 			<key>animatable</key>
@@ -157,6 +161,8 @@
 			<string>Float</string>
 			<key>name</key>
 			<string>ambientIntensity</string>
+			<key>extra</key>
+			<string>min|0|max|1</string>
 		</dict>
 		<dict>
 			<key>defaultSerialization</key>
@@ -171,6 +177,8 @@
 			<string>Float</string>
 			<key>name</key>
 			<string>cutoffRadius</string>
+			<key>extra</key>
+			<string>min|0</string>
 		</dict>
 		<dict>
 			<key>defaultSerialization</key>
@@ -185,6 +193,8 @@
 			<string>Float</string>
 			<key>name</key>
 			<string>halfRadius</string>
+			<key>extra</key>
+			<string>min|0|max|1</string>
 		</dict>
 		<dict>
 			<key>defaultSerialization</key>

--- a/SpriteBuilder/ccBuilder/InspectorFloat.h
+++ b/SpriteBuilder/ccBuilder/InspectorFloat.h
@@ -25,6 +25,9 @@
 #import "InspectorValue.h"
 
 @interface InspectorFloat : InspectorValue
+{
+    IBOutlet NSTextField* textField;
+}
 
 @property (nonatomic,assign) float f;
 

--- a/SpriteBuilder/ccBuilder/InspectorFloat.m
+++ b/SpriteBuilder/ccBuilder/InspectorFloat.m
@@ -26,6 +26,46 @@
 
 @implementation InspectorFloat
 
+- (id) initWithSelection:(CCNode *)s andPropertyName:(NSString *)pn andDisplayName:(NSString *)dn andExtra:(NSString *)e
+{
+    self = [super initWithSelection:s andPropertyName:pn andDisplayName:dn andExtra:e];
+    if (!self) return NULL;
+    
+    return self;
+}
+
+-(void)awakeFromNib
+{
+    [super awakeFromNib];
+
+    NSMutableDictionary *extraDict = [[NSMutableDictionary alloc] init];
+    NSArray* extraParts = [self.extra componentsSeparatedByString:@"|"];
+    NSUInteger pairCount = (extraParts.count / 2);
+    for (NSUInteger pairIndex = 0; pairIndex < pairCount; pairIndex++)
+    {
+        NSString *key = extraParts[2 * pairIndex];
+        NSString *value = extraParts[2 * pairIndex + 1];
+        extraDict[key] = value;
+    }
+
+    // Get the cell from the text field and get the formatter from that.
+    NSTextFieldCell *textFieldCell = (NSTextFieldCell *) textField.cell;
+    NSNumberFormatter *numberFormatter = (NSNumberFormatter *) textFieldCell.formatter;
+    
+    if ((extraDict[@"min"] || extraDict[@"max"]) && numberFormatter)
+    {
+        NSNumberFormatter *stringConverter = [[NSNumberFormatter alloc] init];
+        if (extraDict[@"min"])
+        {
+            numberFormatter.minimum = [stringConverter numberFromString:extraDict[@"min"]];
+        }
+        if (extraDict[@"max"])
+        {
+            numberFormatter.maximum = [stringConverter numberFromString:extraDict[@"max"]];
+        }
+    }
+}
+
 - (void) setF:(float)f
 {
     [self setPropertyForSelection:[NSNumber numberWithFloat:f]];

--- a/SpriteBuilder/ccBuilder/InspectorFloat.xib
+++ b/SpriteBuilder/ccBuilder/InspectorFloat.xib
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="4514" systemVersion="13A3028" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
-        <deployment defaultVersion="1080" identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="4514"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6254"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="InspectorFloat">
             <connections>
+                <outlet property="textField" destination="4" id="pMr-gp-MuQ"/>
                 <outlet property="view" destination="1" id="27"/>
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
-        <customObject id="-3" userLabel="Application"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="1">
             <rect key="frame" x="0.0" y="0.0" width="233" height="33"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
@@ -37,12 +38,7 @@
                     <rect key="frame" x="84" y="12" width="68" height="19"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" drawsBackground="YES" id="5">
-                        <numberFormatter key="formatter" formatterBehavior="custom10_4" positiveFormat="#0.00" negativeFormat="#0.00" numberStyle="decimal" usesGroupingSeparator="NO" minimumIntegerDigits="1" maximumIntegerDigits="309" minimumFractionDigits="2" maximumFractionDigits="2" nilSymbol="L!nDy" id="6">
-                            <real key="roundingIncrement" value="0.0"/>
-                            <metadata>
-                                <bool key="localizesFormat" value="YES"/>
-                            </metadata>
-                        </numberFormatter>
+                        <numberFormatter key="formatter" formatterBehavior="custom10_4" positiveFormat="#0.00" negativeFormat="#0.00" numberStyle="decimal" usesGroupingSeparator="NO" paddingCharacter="*" minimumIntegerDigits="1" maximumIntegerDigits="309" minimumFractionDigits="2" maximumFractionDigits="2" decimalSeparator="." groupingSeparator="," currencyDecimalSeparator="." plusSign="+" minusSign="-" nilSymbol="L!nDy" notANumberSymbol="NaN" perMillSymbol="‰" percentSymbol="%" exponentSymbol="E" positivePrefix="" positiveSuffix="" negativePrefix="-" negativeSuffix="" id="6"/>
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>


### PR DESCRIPTION
- The extra field now supports options of the form "key|value|key|value|..."
- The options "min" and "max" can be used to set the minimum and maximum valid values for the text field cell.
- Update CCLightNode's plist to specify min and max values where appropriate.
