### PR TITLE
Support renaming spritebuilder file.

### DIFF
--- a/SpriteBuilder/ccBuilder/AppDelegate.m
+++ b/SpriteBuilder/ccBuilder/AppDelegate.m
@@ -1660,9 +1660,12 @@ typedef enum
     // Add to recent list of opened documents
     [[NSDocumentController sharedDocumentController] noteNewRecentDocumentURL:[NSURL fileURLWithPath:projectPath]];
 
-    // Convert folder to actual project file
-    NSString* projName = [[projectPath lastPathComponent] stringByDeletingPathExtension];
-    projectPath = [[projectPath stringByAppendingPathComponent:projName] stringByAppendingPathExtension:@"ccbproj"];
+    //Find .ccbproj file
+    NSArray *projectContents = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:projectPath error:nil];
+    NSPredicate *ccbprojExtension = [NSPredicate predicateWithFormat:@"SELF ENDSWITH '.ccbproj'"];
+    NSString *ccbprojFileName = (NSString*)[[projectContents filteredArrayUsingPredicate:ccbprojExtension] firstObject];
+
+    projectPath = [projectPath stringByAppendingPathComponent:ccbprojFileName];
 
     // Load the project file
     NSMutableDictionary* projectDict = [NSMutableDictionary dictionaryWithContentsOfFile:projectPath];


### PR DESCRIPTION
The application currently assumes that a `*.ccbproj` file exists with the same name as the containing `*.spritebuilder` directory. If the top level spritebuilder directory is renamed, then an "invalid project file error" is displayed.

This PR changes the functionality such that the application searches for a *.ccbproj file instead of assuming one exists with a specific name, and so the top level file can be renamed without consequence.
