### PR TITLE
Mac template project view change for cocos2d-v4

### DIFF
--- a/Support/PROJECTNAME.spritebuilder/Source/Platforms/Mac/AppDelegate.m
+++ b/Support/PROJECTNAME.spritebuilder/Source/Platforms/Mac/AppDelegate.m
@@ -1,4 +1,5 @@
 #import "AppDelegate.h"
+#import "CCPackageManager.h"
 
 @interface AppDelegate ()
 

--- a/Support/PROJECTNAME.spritebuilder/Source/Platforms/Mac/AppDelegate.m
+++ b/Support/PROJECTNAME.spritebuilder/Source/Platforms/Mac/AppDelegate.m
@@ -1,5 +1,4 @@
 #import "AppDelegate.h"
-#import "CCPackageManager.h"
 
 @interface AppDelegate ()
 

--- a/Support/PROJECTNAME.spritebuilder/Source/Resources/Platforms/Mac/MainMenu.xib
+++ b/Support/PROJECTNAME.spritebuilder/Source/Resources/Platforms/Mac/MainMenu.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6250" systemVersion="14A389" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6250" systemVersion="14B25" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6250"/>
     </dependencies>
@@ -670,12 +670,12 @@
         <window title="PROJECTNAME" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" animationBehavior="default" id="WbL-ZP-sg3">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <rect key="contentRect" x="109" y="132" width="480" height="320"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1177"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
             <view key="contentView" id="1Kl-CE-vX6">
                 <rect key="frame" x="0.0" y="0.0" width="480" height="320"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <openGLView fixedFrame="YES" colorSize="5bit_RGB_8bit_Alpha" useAuxiliaryDepthBufferStencil="NO" useDoubleBufferingEnabled="YES" allowOffline="YES" wantsBestResolutionOpenGLSurface="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TdD-9J-RVA" customClass="CCGLView">
+                    <openGLView fixedFrame="YES" colorSize="5bit_RGB_8bit_Alpha" useAuxiliaryDepthBufferStencil="NO" useDoubleBufferingEnabled="YES" allowOffline="YES" wantsBestResolutionOpenGLSurface="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TdD-9J-RVA" customClass="CCViewMacGL">
                         <rect key="frame" x="0.0" y="0.0" width="480" height="320"/>
                     </openGLView>
                 </subviews>


### PR DESCRIPTION
Cocos2d version 4 needs a CCViewMacGL, instead of CCGLView.
