### PR TITLE
Updated help link to new URL for MakeSchool, formerly MakeGamesWithUs.

### DIFF
--- a/SpriteBuilder/ccBuilder/AppDelegate.m
+++ b/SpriteBuilder/ccBuilder/AppDelegate.m
@@ -4460,7 +4460,7 @@ typedef enum
 
 - (IBAction)showHelp:(id)sender
 {
-    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:@"http://makegameswith.us/docs/"]];
+    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:@"http://makeschool.com/docs/"]];
 }
 
 - (IBAction)showAPIDocs:(id)sender


### PR DESCRIPTION
We've fully migrated everything to the new domain. This updates the link so it doesn't have to redirect anymore.
