### PR TITLE
Don't serialize a node's code connection when set to doc root var.

### DIFF
--- a/SpriteBuilder/ccBuilder/CCBDictionaryWriter.m
+++ b/SpriteBuilder/ccBuilder/CCBDictionaryWriter.m
@@ -568,8 +568,12 @@
     int memberVarType = [extraProps[@"memberVarAssignmentType"] intValue];
     
     dict[@"customClass"] = customClass;
-    dict[@"memberVarAssignmentName"] = memberVarName;
     dict[@"memberVarAssignmentType"] = @(memberVarType);
+
+    if(memberVarType != 1) //don't copy the node's code connection
+    {
+        dict[@"memberVarAssignmentName"] = memberVarName;
+    }
     
     // JS code connections
     NSString* jsController = extraProps[@"jsController"];


### PR DESCRIPTION
This is designed to fix https://github.com/spritebuilder/SpriteBuilder/issues/1336

Simply doesn't serialize the code connection if the var type is set to `Doc Root Var`
