### PR TITLE
Fix lighting inconsistency between SB and the device / simulator

### DIFF
--- a/SpriteBuilder/CCLightNode/CCBPProperties.plist
+++ b/SpriteBuilder/CCLightNode/CCBPProperties.plist
@@ -198,11 +198,11 @@
 		</dict>
 		<dict>
 			<key>defaultSerialization</key>
-			<integer>1</integer>
+			<integer>100</integer>
 			<key>animatable</key>
 			<true/>
 			<key>default</key>
-			<integer>1</integer>
+			<integer>100</integer>
 			<key>displayName</key>
 			<string>Depth</string>
 			<key>type</key>


### PR DESCRIPTION
- Update Cocos2D to include the cocos part of this fix.
- Set the default and defaultSerialization depth property values to match the default depth value in CCLightNode.
