### PR TITLE
Record test results in circleci

### DIFF
--- a/SpriteBuilder/SpriteBuilder Tests/CreateDirectoryFileCommand_Tests.m
+++ b/SpriteBuilder/SpriteBuilder Tests/CreateDirectoryFileCommand_Tests.m
@@ -18,6 +18,8 @@
 
 - (void)testCreationOfDirectory
 {
+    XCTFail(@"test fail!");
+    
     NSString *dirToCreatePath = [self fullPathForFile:@"new"];
 
     CreateDirectoryFileCommand *createDirectoryFileCommand = [[CreateDirectoryFileCommand alloc] initWithDirPath:dirToCreatePath];

--- a/SpriteBuilder/SpriteBuilder Tests/CreateDirectoryFileCommand_Tests.m
+++ b/SpriteBuilder/SpriteBuilder Tests/CreateDirectoryFileCommand_Tests.m
@@ -18,8 +18,6 @@
 
 - (void)testCreationOfDirectory
 {
-    XCTFail(@"test fail!");
-    
     NSString *dirToCreatePath = [self fullPathForFile:@"new"];
 
     CreateDirectoryFileCommand *createDirectoryFileCommand = [[CreateDirectoryFileCommand alloc] initWithDirPath:dirToCreatePath];

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,9 @@ checkout:
 test:
     override:
         - rake test
-
+    post:
+        - mkdir -p $CIRCLE_TEST_REPORTS/junit/
+        - cp test_results.xml $CIRCLE_TEST_REPORTS/junit/
 deployment:
     develop:
         branch: develop


### PR DESCRIPTION
This just changes the reporters used by xctool and adds a post test step to copy the generated test metadata.

Output can be seen on https://circleci.com/gh/spritebuilder/SpriteBuilder/161
