### PR TITLE
Property readOnly check refactored to inspector property level

### DIFF
--- a/SpriteBuilder/ccBuilder/InspectorPropertyPaneBuilder.m
+++ b/SpriteBuilder/ccBuilder/InspectorPropertyPaneBuilder.m
@@ -202,40 +202,6 @@
     }
 }
 
-- (BOOL)isDisabledProperty:(NSString *)name animatable:(BOOL)animatable
-{
-    // Only animatable properties can be disabled
-    if (!animatable)
-    {
-        return NO;
-    }
-
-    SequencerSequence *sequence = _sequenceHandler.currentSequence;
-    SequencerNodeProperty *sequencerNodeProperty = [_node sequenceNodeProperty:name sequenceId:sequence.sequenceId];
-
-    // Do not disable if animation hasn't been enabled
-    if (!sequencerNodeProperty)
-    {
-        return NO;
-    }
-
-    // Disable visiblilty if there are keyframes
-    if (sequencerNodeProperty.keyframes.count > 0 && [name isEqualToString:@"visible"])
-    {
-        return YES;
-    }
-
-    // Do not disable if we are currently at a keyframe
-    if ([sequencerNodeProperty hasKeyframeAtTime:sequence.timelinePosition])
-    {
-        return NO;
-    }
-
-    // Between keyframes - disable
-    return YES;
-}
-
-
 - (void)resetKeyViewLoop
 {
     NSString *privateFunction = [NSString stringWithFormat:@"%@%@%@", @"_setDefault", @"KeyView", @"Loop"];
@@ -319,10 +285,6 @@
         }
 
         BOOL readOnly = [propInfo[@"readOnly"] boolValue];
-        if ([self isDisabledProperty:name animatable:animated])
-        {
-            readOnly = YES;
-        }
 
         // Handle Flash skews
         BOOL usesFlashSkew = [_node usesFlashSkew];

--- a/SpriteBuilder/ccBuilder/InspectorValue.m
+++ b/SpriteBuilder/ccBuilder/InspectorValue.m
@@ -87,7 +87,45 @@
     if([selection shouldDisableProperty:propertyName])
         return YES;
     
+    if([self isDisabledProperty])
+        return YES;
+    
     return readOnly;
+}
+
+- (BOOL)isDisabledProperty
+{
+    BOOL animatable = [selection.plugIn isAnimatableProperty:propertyName node:selection];
+        
+    // Only animatable properties can be disabled
+    if (!animatable)
+    {
+        return NO;
+    }
+    
+    SequencerSequence *sequence = [SequencerHandler sharedHandler].currentSequence;
+    SequencerNodeProperty *sequencerNodeProperty = [selection sequenceNodeProperty:propertyName sequenceId:sequence.sequenceId];
+    
+    // Do not disable if animation hasn't been enabled
+    if (!sequencerNodeProperty)
+    {
+        return NO;
+    }
+    
+    // Disable visiblilty if there are keyframes
+    if (sequencerNodeProperty.keyframes.count > 0 && [propertyName isEqualToString:@"visible"])
+    {
+        return YES;
+    }
+    
+    // Do not disable if we are currently at a keyframe
+    if ([sequencerNodeProperty hasKeyframeAtTime:sequence.timelinePosition])
+    {
+        return NO;
+    }
+    
+    // Between keyframes - disable
+    return YES;
 }
 
 - (void) updateAffectedProperties


### PR DESCRIPTION
Fixes #1334 
Inspector property `readOnly` status was only being set during initial Inspector Panel build, this has been refactored to update during inspector property refresh.
