### PR TITLE
fixes #691

### DIFF
--- a/SpriteBuilder/ccBuilder/AppDelegate.m
+++ b/SpriteBuilder/ccBuilder/AppDelegate.m
@@ -1898,30 +1898,17 @@ typedef enum
         
     [currentDocument.undoManager removeAllActions];
     currentDocument.lastEditedProperty = NULL;
-    
-    // Generate preview
-    
-    // Reset to first frame in first timeline in first resolution
-    float currentTime = sequenceHandler.currentSequence.timelinePosition;
-    int currentResolution = currentDocument.currentResolution;
-    SequencerSequence* currentSeq = sequenceHandler.currentSequence;
-    
-    sequenceHandler.currentSequence = [currentDocument.sequences objectAtIndex:0];
-    sequenceHandler.currentSequence.timelinePosition = 0;
-    [self reloadResources];
-    //[PositionPropertySetter refreshAllPositions];
-    
+
+    // move to first position to render preview
+    SequencerSequence* first = [currentDocument.sequences objectAtIndex:0];
+    [sequenceHandler setSequenceId:first.sequenceId localTime:0];
+
     // Save preview
     [[CocosScene cocosScene] savePreviewToFile:[fileName stringByAppendingPathExtension:PNG_PREVIEW_IMAGE_SUFFIX]];
-    
-    // Restore resolution and timeline
-    currentDocument.currentResolution = currentResolution;
-    sequenceHandler.currentSequence = currentSeq;
-    [self reloadResources];
-    //[PositionPropertySetter refreshAllPositions];
-    sequenceHandler.currentSequence.timelinePosition = currentTime;
-    
     [projectOutlineHandler updateSelectionPreview];
+    
+    // move back to correct sequence / time to reflect current UI position
+    [sequenceHandler updatePropertiesToTimelinePosition];
 }
 
 - (void) newFile:(NSString*) fileName type:(int)type resolutions: (NSMutableArray*) resolutions;

--- a/SpriteBuilder/ccBuilder/InspectorController.m
+++ b/SpriteBuilder/ccBuilder/InspectorController.m
@@ -22,6 +22,7 @@ static InspectorController *__sharedInstance = nil;
 @property (nonatomic, strong) NSMutableDictionary *currentInspectorValuesMap;
 @property (nonatomic, strong) NSView *inspectorDocumentView;
 @property (nonatomic, strong) NSView *inspectorCodeDocumentView;
+@property (nonatomic, weak) CCNode *lastSelected;
 
 @end
 
@@ -117,6 +118,13 @@ static InspectorController *__sharedInstance = nil;
 
 - (void)updateInspectorFromSelection
 {
+    if (self.lastSelected == _appDelegate.selectedNode) {
+        // don't rebuild if we selecting the same node
+        return;
+    }
+    
+    self.lastSelected = _appDelegate.selectedNode;
+
     [_currentInspectorValuesMap removeAllObjects];
 
     [self buildInspectorPaneWithDocumentView:_inspectorDocumentView

--- a/SpriteBuilder/ccBuilder/SequencerHandler.h
+++ b/SpriteBuilder/ccBuilder/SequencerHandler.h
@@ -109,4 +109,7 @@
 - (void) menuSetSequence:(id)sender;
 - (void) menuSetChainedSequence:(id)sender;
 
+/** Update current document to specified sequence id and point in time */
+- (void) setSequenceId:(int)seqId localTime:(float)time;
+
 @end

--- a/SpriteBuilder/ccBuilder/SequencerHandler.m
+++ b/SpriteBuilder/ccBuilder/SequencerHandler.m
@@ -1531,6 +1531,11 @@ static SequencerHandler* sharedSequencerHandler;
     }
 }
 
+- (void) setSequenceId:(int)seqId localTime:(float)time
+{
+    [self updatePropertiesToTimelinePositionForNode:[[CocosScene cocosScene] rootNode] sequenceId:seqId localTime:time];
+}
+
 - (void) updatePropertiesToTimelinePosition
 {
     [self updatePropertiesToTimelinePositionForNode:[[CocosScene cocosScene] rootNode] sequenceId:currentSequence.sequenceId localTime:currentSequence.timelinePosition];


### PR DESCRIPTION
Few things about this commit, but worth a thorough review
- assumes saving a document does not change the scene graph, which
  would require a full tear-down and rebuild. I would consider save code
  needs refactoring if this is not the case
- exposes a new method to set a specific sequenceId and local time
  without changing the UI state, so the preview can be generated at the
  first sequence and local time of zero
- I did not see the resolution was modified, nor was it updated during a
  save, so I removed that redundant code
