### PR TITLE
FIX: Remove auto layout from Mac XIB

### DIFF
--- a/Support/PROJECTNAME.spritebuilder/Source/Resources/Platforms/Mac/MainMenu.xib
+++ b/Support/PROJECTNAME.spritebuilder/Source/Resources/Platforms/Mac/MainMenu.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6250" systemVersion="14B25" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6250"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6254"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -675,8 +675,9 @@
                 <rect key="frame" x="0.0" y="0.0" width="480" height="320"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <openGLView fixedFrame="YES" colorSize="5bit_RGB_8bit_Alpha" useAuxiliaryDepthBufferStencil="NO" useDoubleBufferingEnabled="YES" allowOffline="YES" wantsBestResolutionOpenGLSurface="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TdD-9J-RVA" customClass="CCViewMacGL">
+                    <openGLView colorSize="5bit_RGB_8bit_Alpha" useAuxiliaryDepthBufferStencil="NO" useDoubleBufferingEnabled="YES" allowOffline="YES" wantsBestResolutionOpenGLSurface="YES" id="TdD-9J-RVA" customClass="CCViewMacGL">
                         <rect key="frame" x="0.0" y="0.0" width="480" height="320"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     </openGLView>
                 </subviews>
             </view>


### PR DESCRIPTION
Hello,

I've been trying to change the default frame of the Mac application from the AppDelegate, without luck. After overriding the `CCGLView`'s `setFrame:`, it seems the autolayout constraints are fighting against the `setFrame:` call in the app delegate.

All this PR does is unchecks the autolayout box in the template project, since it should not be needed anyway.

_P.S._: Sorry about the tools version change, I am not sure if that is required or not.

Thanks,
Maz
