### PR TITLE
Disable app sandbox.

### DIFF
--- a/SpriteBuilder/SpriteBuilder.xcodeproj/project.pbxproj
+++ b/SpriteBuilder/SpriteBuilder.xcodeproj/project.pbxproj
@@ -6395,7 +6395,7 @@
 						DevelopmentTeam = U2K5E32W7G;
 						SystemCapabilities = {
 							com.apple.Sandbox = {
-								enabled = 1;
+								enabled = 0;
 							};
 						};
 					};


### PR DESCRIPTION
This disables the app sandbox for builds of SpriteBuilder.

This is a fix for multiple issues relating to file permissions, most notably the ability for the user to set a custom output directory for packaged assets + zip files. 
