### PR TITLE
Add the project name to spritesheet cache directory.

### DIFF
--- a/SpriteBuilder/ccBuilder/CCBDirectoryPublisher.m
+++ b/SpriteBuilder/ccBuilder/CCBDirectoryPublisher.m
@@ -425,7 +425,8 @@
                                 attributes:nil
                                      error:nil];
         
-        NSString *intermediateFileLookupPath = [[_projectSettings.tempSpriteSheetCacheDirectory stringByAppendingPathComponent:subPathWithRes] stringByAppendingPathComponent:INTERMEDIATE_FILE_LOOKUP_NAME];
+        NSString *intermediateFileLookupPath = [[_projectSettings.tempSpriteSheetCacheDirectory stringByAppendingPathComponent:subPathWithRes]
+                stringByAppendingPathComponent:INTERMEDIATE_FILE_LOOKUP_NAME];
         [_renamedFilesLookup addIntermediateLookupPath:intermediateFileLookupPath];
 
 		if ([self spriteSheetExistsAndUpToDate:srcSpriteSheetDate spriteSheetFile:spriteSheetFile subPath:subPathWithRes])
@@ -474,16 +475,19 @@
                                                                                           packageSettings:_packageSettings
                                                                                                  warnings:_warnings
                                                                                            statusProgress:_publishingTaskStatusProgress];
+
+    NSString *spriteSheetCacheDir = [_projectSettings.tempSpriteSheetCacheDirectory stringByAppendingPathComponent:subPath];
+    NSString *resolutionCacheDir = [spriteSheetCacheDir stringByAppendingPathComponent:[NSString stringWithFormat:@"resources-%@", resolution]];
+
     operation.publishDirectory = publishDirectory;
     operation.publishedPNGFiles = _publishedPNGFiles;
     operation.srcSpriteSheetDate = srcSpriteSheetDate;
     operation.resolution = resolution;
-    operation.srcDirs = @[
-            [[_projectSettings.tempSpriteSheetCacheDirectory stringByAppendingPathComponent:subPath] stringByAppendingPathComponent:[NSString stringWithFormat:@"resources-%@", resolution]],
-            [_projectSettings.tempSpriteSheetCacheDirectory stringByAppendingPathComponent:subPath]];
+    operation.srcDirs = @[resolutionCacheDir, spriteSheetCacheDir];
     operation.spriteSheetFile = spriteSheetFile;
     operation.subPath = subPath;
     operation.osType = _osType;
+
     return operation;
 }
 

--- a/SpriteBuilder/ccBuilder/ProjectSettings.m
+++ b/SpriteBuilder/ccBuilder/ProjectSettings.m
@@ -298,7 +298,10 @@ NSString *const PROJECTSETTINGS_KEY_DEPRECATED_EXCLUDEFROMPACKAGEMIGRATION = @"e
 - (NSString*) tempSpriteSheetCacheDirectory
 {
     NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
-    return [[paths[0] stringByAppendingPathComponent:PUBLISHER_CACHE_DIRECTORY_NAME] stringByAppendingPathComponent:@"spritesheet"];
+    NSString *cacheDir = [paths[0] stringByAppendingPathComponent:PUBLISHER_CACHE_DIRECTORY_NAME];
+    NSString *projectDir = [NSString stringWithFormat:@"%@-spritesheet", [_projectPath lastPathComponent]];
+
+    return [cacheDir stringByAppendingPathComponent:projectDir];
 }
 
 - (void) _storeDelayed


### PR DESCRIPTION
This review modifies the name of spritesheet cache directory to prevent collisions across multiple projects that share the same spritesheet names. This is designed to address #1467
