### PR TITLE
Publishing fixes.

### DIFF
--- a/SpriteBuilder/SpriteBuilder Tests/CCBPublisher_Tests.m
+++ b/SpriteBuilder/SpriteBuilder Tests/CCBPublisher_Tests.m
@@ -262,9 +262,9 @@
     // The resolutions tests may be a bit too much here, but there are no
     // Tupac tests at the moment
     [self assertFileExists:@"Published-iOS/sheet-2x.plist"];
-    [self assertPNGAtPath:@"Published-iOS/sheet-2x.png" hasWidth:32 hasHeight:16];
+    [self assertPNGAtPath:@"Published-iOS/sheet-2x.png" hasWidth:16 hasHeight:16];
     [self assertFileExists:@"Published-iOS/sheet-4x.plist"];
-    [self assertPNGAtPath:@"Published-iOS/sheet-4x.png" hasWidth:32 hasHeight:32];
+    [self assertPNGAtPath:@"Published-iOS/sheet-4x.png" hasWidth:32 hasHeight:16];
     [self assertFileExists:@"Published-iOS/sheet-1x.plist"];
     [self assertPNGAtPath:@"Published-iOS/sheet-1x.png" hasWidth:16 hasHeight:8];
 

--- a/SpriteBuilder/ccBuilder/CCBDirectoryPublisher.m
+++ b/SpriteBuilder/ccBuilder/CCBDirectoryPublisher.m
@@ -480,13 +480,12 @@
                                                                                            statusProgress:_publishingTaskStatusProgress];
 
     NSString *spriteSheetCacheDir = [_projectSettings.tempSpriteSheetCacheDirectory stringByAppendingPathComponent:subPath];
-    NSString *resolutionCacheDir = [spriteSheetCacheDir stringByAppendingPathComponent:[NSString stringWithFormat:@"resources-%@", resolution]];
 
     operation.publishDirectory = publishDirectory;
     operation.publishedPNGFiles = _publishedPNGFiles;
     operation.srcSpriteSheetDate = srcSpriteSheetDate;
     operation.resolution = resolution;
-    operation.srcDirs = @[resolutionCacheDir, spriteSheetCacheDir];
+    operation.srcDir = spriteSheetCacheDir;
     operation.spriteSheetFile = spriteSheetFile;
     operation.subPath = subPath;
     operation.osType = _osType;

--- a/SpriteBuilder/ccBuilder/PublishGeneratedFilesOperation.m
+++ b/SpriteBuilder/ccBuilder/PublishGeneratedFilesOperation.m
@@ -98,6 +98,11 @@
     {
         [_warnings addWarningWithDescription:@"Could not write fileLookup.plist."];
     }
+    
+    if (![_fileLookup TEMPwriteMetadataToFileAtomically:[_outputDir stringByAppendingPathComponent:@"metadata.plist"]])
+    {
+        [_warnings addWarningWithDescription:@"Could not write metadata.plist."];
+    }
 }
 
 - (NSString *)description

--- a/SpriteBuilder/ccBuilder/PublishImageOperation.m
+++ b/SpriteBuilder/ccBuilder/PublishImageOperation.m
@@ -131,6 +131,7 @@
                                            dither:_dither
                                          compress:_compress
                                     isSpriteSheet:_isSpriteSheet
+                                    isAutoScaled:NO
                                    outputFilename:&dstPathConverted
                                             error:&error])
         {
@@ -183,6 +184,7 @@
                                            dither:_dither
                                          compress:_compress
                                     isSpriteSheet:_isSpriteSheet
+                                     isAutoScaled:NO
                                    outputFilename:&dstPathConverted
                                             error:&error])
         {

--- a/SpriteBuilder/ccBuilder/PublishRenamedFilesLookup.h
+++ b/SpriteBuilder/ccBuilder/PublishRenamedFilesLookup.h
@@ -6,6 +6,7 @@
 - (void)addRenamingRuleFrom:(NSString *)src to:(NSString *)dst;
 
 - (BOOL)writeToFileAtomically:(NSString *)filePath;
+- (BOOL)TEMPwriteMetadataToFileAtomically:(NSString *)filePath;
 
 - (void)addIntermediateLookupPath:(NSString *)filePath;
 

--- a/SpriteBuilder/ccBuilder/PublishRenamedFilesLookup.m
+++ b/SpriteBuilder/ccBuilder/PublishRenamedFilesLookup.m
@@ -50,6 +50,20 @@
     return [plist writeToFile:filePath atomically:YES];
 }
 
+- (BOOL)TEMPwriteMetadataToFileAtomically:(NSString *)filePath
+{
+    NSMutableDictionary *intermediateLookups = [self loadAndMergeIntermediateLookups];
+    [_lookup addEntriesFromDictionary:intermediateLookups];
+    
+    NSMutableDictionary *data = [NSMutableDictionary dictionary];
+    for(NSString *alias in _lookup){
+        data[alias] = @{@"filename": _lookup[alias]};
+    }
+    
+    NSDictionary *metadata = @{@"data": data};
+    return [metadata writeToFile:filePath atomically:YES];
+}
+
 - (NSMutableDictionary *)loadAndMergeIntermediateLookups
 {
     NSMutableDictionary *result = [NSMutableDictionary dictionary];

--- a/SpriteBuilder/ccBuilder/PublishSpriteSheetOperation.h
+++ b/SpriteBuilder/ccBuilder/PublishSpriteSheetOperation.h
@@ -11,7 +11,7 @@
 @property (nonatomic, copy) NSString *spriteSheetFile;
 @property (nonatomic) CCBPublisherOSType osType;
 @property (nonatomic, copy) NSString *subPath;
-@property (nonatomic, strong) NSArray *srcDirs;
+@property (nonatomic, copy) NSString *srcDir;
 @property (nonatomic, copy) NSNumber *resolution;
 @property (nonatomic, copy) NSDate *srcSpriteSheetDate;
 @property (nonatomic, copy) NSString *publishDirectory;

--- a/SpriteBuilder/ccBuilder/PublishSpriteSheetOperation.m
+++ b/SpriteBuilder/ccBuilder/PublishSpriteSheetOperation.m
@@ -56,7 +56,7 @@ static NSMutableSet *__spriteSheetPreviewsGenerated;
 {
     NSAssert(_spriteSheetFile != nil, @"spriteSheetFile should not be nil");
     NSAssert(_subPath != nil, @"subPath should not be nil");
-    NSAssert(_srcDirs != nil, @"srcDirs should not be nil");
+    NSAssert(_srcDir != nil, @"srcDir should not be nil");
     NSAssert(_resolution != nil, @"resolution should not be nil");
     NSAssert(_srcSpriteSheetDate != nil, @"srcSpriteSheetDate should not be nil");
     NSAssert(_publishDirectory != nil, @"publishDirectory should not be nil");
@@ -73,7 +73,8 @@ static NSMutableSet *__spriteSheetPreviewsGenerated;
 
     [self configurePacker];
 
-    NSArray *createdFiles = [_packer createTextureAtlasFromDirectoryPaths:_srcDirs];
+    NSString *suffix = [NSString stringWithFormat:@"-%dx", self.resolution.intValue];
+    NSArray *createdFiles = [_packer createTextureAtlasFromDirectoryPath:_srcDir withSuffix:suffix];
 
     [self addCreatedPNGFilesToCreatedFilesSet:createdFiles];
 
@@ -190,8 +191,8 @@ static NSMutableSet *__spriteSheetPreviewsGenerated;
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"file: %@, res: %@, osType: %i, filefull: %@, srcdirs: %@, publishDirectory: %@, date: %@",
-                                      [_spriteSheetFile lastPathComponent], _resolution, _osType, _spriteSheetFile, _srcDirs, _publishDirectory, _srcSpriteSheetDate];
+    return [NSString stringWithFormat:@"file: %@, res: %@, osType: %i, filefull: %@, srcdir: %@, publishDirectory: %@, date: %@",
+                                      [_spriteSheetFile lastPathComponent], _resolution, _osType, _spriteSheetFile, _srcDir, _publishDirectory, _srcSpriteSheetDate];
 }
 
 

--- a/SpriteBuilder/libs/FCFormatConverter/FCFormatConverter.h
+++ b/SpriteBuilder/libs/FCFormatConverter/FCFormatConverter.h
@@ -41,6 +41,7 @@ typedef enum {
                    dither:(BOOL)dither
                  compress:(BOOL)compress
             isSpriteSheet:(BOOL)isSpriteSheet
+            isAutoScaled:(BOOL)isAutoScaled
            outputFilename:(NSString**)outputFilename
                     error:(NSError**)error;
 

--- a/SpriteBuilder/libs/Tupac/Tupac.h
+++ b/SpriteBuilder/libs/Tupac/Tupac.h
@@ -41,6 +41,7 @@
 @property(nonatomic,copy) NSString* directoryPrefix;
 @property(nonatomic,assign) int maxTextureSize;
 @property(nonatomic,assign) int padding;
+@property(nonatomic,assign) int divisor;
 @property(nonatomic,assign) BOOL dither;
 @property(nonatomic,assign) BOOL compress;
 @property(nonatomic,assign) BOOL trim;

--- a/SpriteBuilder/libs/Tupac/Tupac.h
+++ b/SpriteBuilder/libs/Tupac/Tupac.h
@@ -50,8 +50,8 @@
 
 + (NSRect) trimmedRectForImage:(CGImageRef)image;
 
-- (NSArray *)createTextureAtlasFromDirectoryPaths:(NSArray *)dirs;
-- (NSArray *)createTextureAtlas;
+- (NSArray *)createTextureAtlasFromDirectoryPath:(NSString *)dir withSuffix:(NSString *)suffix;
+- (NSArray *)createTextureAtlasTrimSuffix:(NSString *)suffix;
 
 - (void)cancel;
 

--- a/SpriteBuilder/libs/Tupac/Tupac.mm
+++ b/SpriteBuilder/libs/Tupac/Tupac.mm
@@ -200,7 +200,17 @@ typedef struct _PVRTexHeader
     return NSMakeRect(x, y, wTrimmed, hTrimmed);
 }
 
-- (NSArray *)createTextureAtlas
+static NSString *
+TrimSuffix(NSString *filename, NSString *suffix)
+{
+    NSString *basename = [filename stringByDeletingPathExtension];
+    if([basename hasSuffix:suffix]) basename = [basename substringToIndex:basename.length - suffix.length];
+    NSString *ext = [filename pathExtension];
+    
+    return [basename stringByAppendingPathExtension:ext];
+}
+
+- (NSArray *)createTextureAtlasTrimSuffix:(NSString *)suffix
 {
     // Reset the error message
     if (errorMessage)
@@ -504,7 +514,7 @@ typedef struct _PVRTexHeader
         {
             // Get info about the image
             NSString* filename = self.filenames[(NSUInteger) outRects[index].idx];
-            NSString* exportFilename = [filename lastPathComponent];
+            NSString* exportFilename = TrimSuffix([filename lastPathComponent], suffix);
             if (directoryPrefix_) exportFilename = [directoryPrefix_ stringByAppendingPathComponent:exportFilename];
             NSDictionary* imageInfo = imageInfos[(NSUInteger) outRects[index].idx];
             
@@ -540,7 +550,7 @@ typedef struct _PVRTexHeader
                     @"sourceSize" : NSStringFromSize(NSMakeSize(wSrc, hSrc))};
         }
         
-        metadata[@"textureFileName"] = textureFileName;
+        metadata[@"textureFileName"] = TrimSuffix(textureFileName, suffix);
         metadata[@"format"] = @2;
         metadata[@"size"] = NSStringFromSize(NSMakeSize(outW, outH));
 
@@ -574,52 +584,33 @@ typedef struct _PVRTexHeader
     }
 }
 
-- (NSArray *) createTextureAtlasFromDirectoryPaths:(NSArray *)dirs
+- (NSArray *) createTextureAtlasFromDirectoryPath:(NSString *)dir withSuffix:(NSString *)suffix;
 {
     NSFileManager* fm = [NSFileManager defaultManager];
     
-    // Build a list of all file names from all directories
-    NSMutableSet* allFiles = [NSMutableSet set];
-    
-    for (NSString* dir in dirs)
-    {
-        NSArray* files = [fm contentsOfDirectoryAtPath:dir error:NULL];
-
-        if (cancelled_)
-        {
-            return nil;
-        }
-
-        for (NSString* file in files)
-        {
-				    NSString *lower = [[file pathExtension] lowercaseString];
-            if ([lower isEqualToString:@"png"] || [lower isEqualToString:@"psd"])
-            {
-                [allFiles addObject:[file lastPathComponent]];
-            }
-        }
-    }
-    
     // Add all the absolute file names to an array from the correct directories
     NSMutableArray* absoluteFilepaths = [NSMutableArray array];
-    for (NSString* file in allFiles)
+    
+    NSArray* files = [fm contentsOfDirectoryAtPath:dir error:NULL];
+
+    if (cancelled_)
     {
-        for (NSString* dir in dirs)
+        return nil;
+    }
+
+    for (NSString* file in files)
+    {
+        NSString *ext = [[file pathExtension] lowercaseString];
+        NSString *basename = [file stringByDeletingPathExtension];
+        if ([basename hasSuffix:suffix] && ([ext isEqualToString:@"png"] || [ext isEqualToString:@"psd"]))
         {
-            NSString* absFilepath = [dir stringByAppendingPathComponent:file];
-            
-            if ([fm fileExistsAtPath:absFilepath])
-            {
-                [absoluteFilepaths addObject:absFilepath];
-                //foundFile = YES;
-                break;
-            }
+            [absoluteFilepaths addObject:[dir stringByAppendingPathComponent:file]];
         }
     }
     
     // Generate the sprite sheet
     self.filenames = absoluteFilepaths;
-    return [self createTextureAtlas];
+    return [self createTextureAtlasTrimSuffix:suffix];
 }
 
 - (void)cancel

--- a/SpriteBuilder/libs/Tupac/Tupac.mm
+++ b/SpriteBuilder/libs/Tupac/Tupac.mm
@@ -471,6 +471,7 @@ typedef struct _PVRTexHeader
                                       dither:dither_
                                     compress:compress_
                                isSpriteSheet:YES
+                                isAutoScaled:NO
                               outputFilename:&textureFileName
                                        error:&error])
     {

--- a/SpriteBuilder/libs/Tupac/Tupac.mm
+++ b/SpriteBuilder/libs/Tupac/Tupac.mm
@@ -92,6 +92,7 @@ typedef struct _PVRTexHeader
         self.outputFormat = TupacOutputFormatCocos2D;
         self.maxTextureSize = 2048;
         self.padding = 1;
+        self.divisor = 1;
         self.trim = YES;
     }
     return self;
@@ -210,6 +211,13 @@ TrimSuffix(NSString *filename, NSString *suffix)
     return [basename stringByAppendingPathExtension:ext];
 }
 
+// Pad a size and round the result up to a multiple of the divisor
+static int
+PadSize(int size, int padding, int divisor)
+{
+    return (size + padding + divisor - 1)/divisor*divisor;
+}
+
 - (NSArray *)createTextureAtlasTrimSuffix:(NSString *)suffix
 {
     // Reset the error message
@@ -322,7 +330,7 @@ TrimSuffix(NSString *filename, NSString *suffix)
     BOOL packingError = NO;
     while (!packingError && !allFitted)
     {
-        MaxRectsBinPack bin(outW, outH);
+        MaxRectsBinPack bin(outW - self.padding, outH - self.padding);
         
         std::vector<TPRectSize> inRects;
         
@@ -332,8 +340,8 @@ TrimSuffix(NSString *filename, NSString *suffix)
             NSRect trimRect = [imageInfo[@"trimRect"] rectValue];
             
             inRects.push_back(TPRectSize());
-            inRects[numImages].width = (int) (trimRect.size.width + self.padding * 2);
-            inRects[numImages].height = (int) (trimRect.size.height + self.padding * 2);
+            inRects[numImages].width = PadSize(trimRect.size.width, self.padding, self.divisor);
+            inRects[numImages].height = PadSize(trimRect.size.height, self.padding, self.divisor);
             inRects[numImages].idx = numImages;
             
             numImages++;


### PR DESCRIPTION
Two fixes so far:
1. Added an argument to FCFormatConverter to request mipmap generation when exporting PVR files.
2. Spritesheets were being generated incorrectly. (Ex: `Foo.plist` would contain references to `Bar-1x.png`, `Bar-2x.png` and `Bar-4x.png`) I'm not very certain that my fix for this is correct. It seems like there are a lot of dead paths through the code here that never actually happen.

Will see how far I can get with the metadata generation tomorrow. It's preventing PVR and JPEG files from loading since there is no filename aliasing data exported yet.

@rkachowski and/or @vlidholt  If you can review ASAP, that would be helpful. I'm don't know the publishing code very well.
